### PR TITLE
add:添加esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "pkgwin": "pkg . -t node14-win-x64 -C GZip -o bin/app_win --no-bytecode",
     "pkglinux": "pkg . -t node14-linux-x64 -C GZip -o bin/app_linux --no-bytecode",
     "pkgmacos": "pkg . -t node14-macos-x64 -C GZip -o bin/app_macos --no-bytecode",
-    "pkgwin_lite": "pkg . -t node14-win-x64 --options platform=lite -C GZip -o bin/app_win --no-bytecode"
+    "pkgwin_lite": "pkg . -t node14-win-x64 --options platform=lite -C GZip -o bin/app_win --no-bytecode",
+    "pkgjs": "esbuild index.js --bundle --minify --outfile=bin/api_js/app.js --platform=node && cp -r module bin/api_js/ && cp -r util bin/api_js/ "
   },
   "engines": {
     "node": ">=12"
@@ -41,7 +42,7 @@
     "@types/node": "^18.11.9",
     "@types/pako": "^2.0.0",
     "@types/qrcode": "^1.5.0",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.1.10",
     "pkg": "^5.8.1",
     "prettier": "^2.7.1",
     "ts-node": "^10.9.1",
@@ -50,6 +51,7 @@
   "dependencies": {
     "axios": "^1.1.3",
     "dotenv": "^16.4.5",
+    "esbuild": "^0.25.3",
     "express": "^4.18.2",
     "pako": "^2.1.0",
     "qrcode": "^1.5.3",


### PR DESCRIPTION
打包后在任何有node环境下运行（包括android），打包文件在 ./bin/api_js/ 下，复制所有文件到对应环境中使用node执行即可