### PR TITLE
手机号登录添加通过userid选择用户

### DIFF
--- a/interface.d.ts
+++ b/interface.d.ts
@@ -43,7 +43,7 @@ export function getModulesDefinitions(modulesPath: string, specificRoute: Record
 export function createRequest(params: UseAxiosRequestConfig): Promise<UseAxiosResponse>;
 
 // API
-export function login_cellphone(params: { mobile: number; code: number | string } & RequestBaseConfig): Promise<Response>;
+export function login_cellphone(params: { mobile: number; code: number | string; userid?: string | number } & RequestBaseConfig): Promise<Response>;
 
 export function login(params: { username: string; password: string } & RequestBaseConfig): Promise<UseAxiosResponse>;
 

--- a/module/login_cellphone.js
+++ b/module/login_cellphone.js
@@ -14,6 +14,7 @@ module.exports = (params, useAxios) => {
     clienttime_ms: dateTime,
     mobile: params.mobile,
     key: signParamsKey(dateTime),
+    userid:  params?.userid
   };
 
   if (isLite) {


### PR DESCRIPTION
添加可通过userid选择要登录的账户
在使用手机号登录时可能会有多账号的情况，
此时会报502且返回数据:
```json
{
    "data": {
        "info_list": [
            {
                "nickname": "xxx",
                "pic": "http://imge.kugou.com/kugouicon/165/20250814/xxxxxx.jpg",
                "userid": 111111111,
                "appid": xxxx,
                "username": "xxxx"
            },
            {
                "nickname": "xxxx",
                "pic": "http://imge.kugou.com/kugouicon/165/20160113/xxxxxxx.jpg",
                "userid": 222222222,
                "appid": xxxx,
                "username": "xxxx"
            }
        ]
    },
    "status": 0,
    "error_code": 34175
}
```
---
添加了通过userid来选择要登录的账户
```ts
/** 手机登录 */
export function phoneLogin(mobile: string, code: string, userid?:string) {
  return get('/login/cellphone',{mobile, code, timestamp: Date.now(),userid})
}
```

（抓包找到的方案喵？手机登录多账号会有选择账号界面，选择后会发起带userid的请求喵）