### PR TITLE
Linux: 增加ARM64架构支持

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "start": "node app.js",
     "pkgwin": "pkg . -t node14-win-x64 -C GZip -o bin/app_win --no-bytecode",
     "pkglinux": "pkg . -t node14-linux-x64 -C GZip -o bin/app_linux --no-bytecode",
+    "pkglinux-arm64": "pkg . -t node14-linux-arm64 -C GZip -o bin/app_linux --no-bytecode",
     "pkgmacos": "pkg . -t node14-macos-x64 -C GZip -o bin/app_macos --no-bytecode",
     "pkgjs": "esbuild index.js --bundle --minify --outfile=bin/api_js/app.js --platform=node && mkdir -p bin/api_js/util bin/api_js/module && esbuild util/*.js --bundle --minify --outdir=bin/api_js/util --platform=node && esbuild module/*.js --bundle --minify --outdir=bin/api_js/module --platform=node"
   },


### PR DESCRIPTION
该API经过本人测试, 能在ARM64架构的Linux下完美运行, 但上游在package.json里还没有对ARM64架构的GNU/Linux系统的直接支持, 故提交此PR完善上游对GNU/Linux发行版的ARM64架构直接支持

测试系统: Debian 13
CPU: Qualcomm SnapDragon 860
GPU Driver: Freedreno (Mesa 26.0.0-rc2)