### PR TITLE
feat(api): add /audio/proxy and harden CORS/cache policies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,16 @@ PORT=''
 ## HTTP 代理地址 (可选)
 KUGOU_API_PROXY=''
 
+## 可选：仅对该来源启用 CORS（例如 https://example.com）
+## 仅对跨域请求生效
+CORS_ALLOW_ORIGIN=''
+
+## 音频代理允许列表（以逗号分隔的主机后缀）
+AUDIO_PROXY_ALLOW_HOSTS='kugou.com'
+
+## 音频代理超时时间，单位毫秒
+AUDIO_PROXY_TIMEOUT='20000'
+
 ## 设备id(可选，建议固定 )
 ## KUGOU_API_GUID 建议为 uuidv4
 ## KUGOU_API_DEV 建议长度为 10 位的字符串


### PR DESCRIPTION
- 问题描述：
  Web 端 HTTPS 部署MoeKoeMusic时，音频资源来自第三方域名（如 `*.kugou.com`），浏览器因目标站点缺失 `Access-Control-Allow-Origin` 拒绝播放。  
- 更改： 
  通过服务端新增音频流式中转实现同源访问；前端将播放地址改写为 `/api/audio/proxy?...`。  
  后端同步收紧 CORS 和方法白名单，并对登录态响应禁用缓存。
- 版权问题：
  新增的 /audio/proxy 仅做流式透传，不落盘、不转码、不持久化缓存，且不改变现有鉴权链路（登录态下强制 Cache-Control: no-store）；
  同时为降低滥用风险，接口仅允许 GET/HEAD，并可通过设置 AUDIO_PROXY_ALLOW_HOSTS（默认 kugou.com）限制可代理域名，避免开放代理。
  CORS 侧也由默认放开改为仅在显式配置 CORS_ALLOW_ORIGIN 且确为跨域请求时生效。