### PR TITLE
fix: 支持歌单和专辑楼层评论

### DIFF
--- a/module/comment_floor.js
+++ b/module/comment_floor.js
@@ -1,23 +1,59 @@
-// 歌曲评论
-module.exports = (params, useAxios) => {
+// 楼层评论
+const songCode = 'fc4be23b4e972707f36b8a828a93ba8a';
+const playlistCode = 'ca53b96fe5a1d9c22d71c8f522ef7c4f';
+const albumCode = '94f1792ced1df89aa68a7939eaf2efca';
+
+const isNonEmpty = (value) => {
+  if (value == null) return false;
+  const text = `${value}`.trim();
+  return text !== '' && text !== 'null' && text !== 'undefined';
+};
+
+const resolveFloorCommentRequestConfig = (params = {}) => {
+  const resourceType = `${params.resource_type || params.resourceType || ''}`.toLowerCase();
+  const code = isNonEmpty(params.code)
+    ? `${params.code}`
+    : resourceType === 'playlist'
+        ? playlistCode
+        : resourceType === 'album'
+            ? albumCode
+            : songCode;
+
+  const useServiceEndpoint =
+    resourceType === 'playlist' ||
+    resourceType === 'album' ||
+    code === playlistCode ||
+    code === albumCode;
 
   const paramsMap = {
     childrenid: params.special_id,
-    mixsongid: params.mixsongid,
     need_show_image: 1,
     p: params.page || 1,
     pagesize: params.pagesize || 30,
-    show_classify: params.show_classify || 1,
-    show_hotword_list: params.show_hotword_list || 1,
-    code: 'fc4be23b4e972707f36b8a828a93ba8a',
-    tid: params.tid
+    show_classify: params.show_classify ?? 1,
+    show_hotword_list: params.show_hotword_list ?? 1,
+    code,
+    tid: params.tid,
+  };
+
+  if (isNonEmpty(params.mixsongid)) {
+    paramsMap.mixsongid = params.mixsongid;
   }
 
-  return useAxios({
-    url: '/mcomment/v1/hot_replylist',
+  return {
+    url: useServiceEndpoint
+      ? '/m.comment.service/v1/hot_replylist'
+      : '/mcomment/v1/hot_replylist',
     encryptType: 'android',
     method: 'POST',
     params: paramsMap,
     cookie: params?.cookie || {},
-  });
+  };
 };
+
+const commentFloor = (params, useAxios) => {
+  return useAxios(resolveFloorCommentRequestConfig(params));
+};
+
+module.exports = commentFloor;
+module.exports.resolveFloorCommentRequestConfig = resolveFloorCommentRequestConfig;

--- a/module/comment_floor.test.js
+++ b/module/comment_floor.test.js
@@ -1,0 +1,44 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const commentFloor = require('./comment_floor');
+
+test('song floor comments keep using the song endpoint and mixsongid', () => {
+  const config = commentFloor.resolveFloorCommentRequestConfig({
+    special_id: '100285259',
+    mixsongid: '302362878',
+    tid: '678433417',
+  });
+
+  assert.equal(config.url, '/mcomment/v1/hot_replylist');
+  assert.equal(config.params.childrenid, '100285259');
+  assert.equal(config.params.mixsongid, '302362878');
+  assert.equal(config.params.code, 'fc4be23b4e972707f36b8a828a93ba8a');
+});
+
+test('playlist floor comments switch to service endpoint and playlist code', () => {
+  const config = commentFloor.resolveFloorCommentRequestConfig({
+    special_id: 'collection_3_1373407643_366_0',
+    tid: '9380261',
+    resource_type: 'playlist',
+  });
+
+  assert.equal(config.url, '/m.comment.service/v1/hot_replylist');
+  assert.equal(config.params.childrenid, 'collection_3_1373407643_366_0');
+  assert.equal(config.params.tid, '9380261');
+  assert.equal(config.params.code, 'ca53b96fe5a1d9c22d71c8f522ef7c4f');
+  assert.ok(!('mixsongid' in config.params));
+});
+
+test('album floor comments can be resolved from album comment code alone', () => {
+  const config = commentFloor.resolveFloorCommentRequestConfig({
+    special_id: '179005522',
+    tid: '13712359',
+    code: '94f1792ced1df89aa68a7939eaf2efca',
+  });
+
+  assert.equal(config.url, '/m.comment.service/v1/hot_replylist');
+  assert.equal(config.params.childrenid, '179005522');
+  assert.equal(config.params.tid, '13712359');
+  assert.equal(config.params.code, '94f1792ced1df89aa68a7939eaf2efca');
+});


### PR DESCRIPTION
## 概要
这个 PR 修复了 /comment/floor，使其在保持歌曲楼层评论兼容的前提下，正确支持：

- 歌单楼层评论
- 专辑楼层评论

之前的 comment_floor 实现实际上是歌曲专用代理：

- 固定请求歌曲楼层评论上游接口
- 固定使用歌曲评论 code
- 默认强依赖 mixsongid

因此会导致：

- 歌曲楼层评论可用
- 歌单 / 专辑楼层评论不可用

## 修改内容
- 修改 module/comment_floor.js
   - 根据 resource_type / code 自动判断资源类型
- 保持歌曲继续走：
   - /mcomment/v1/hot_replylist
- 让歌单 / 专辑改走：
   - /m.comment.service/v1/hot_replylist
- 支持透传：
   - code
   - resource_type
- mixsongid 改为仅在存在时透传，不再对歌单 / 专辑强依赖

- 新增回归测试：
  - module/comment_floor.test.js

- 修改后的行为
  - /comment/floor 现在支持：

    - 歌曲
       - 继续沿用原有逻辑
    - 歌单
       - 正确请求评论服务接口
    - 专辑
       - 正确请求评论服务接口

## 验证

- 已完成：
   - node --test module/comment_floor.test.js
   - 基于真实样本的上游接口验证

- 验证结果：
   - playlist：err_code=0
   - album：err_code=0

## 说明

这个 PR 没有新增新的对外路由，对外仍然是：
- /comment/floor

只是内部改为根据资源类型正确分流。