### PR TITLE
feat: 列出私信消息历史

### DIFF
--- a/module/message_history.js
+++ b/module/message_history.js
@@ -1,0 +1,36 @@
+//列出消息历史
+const { cryptoAesEncrypt, appid, mid,signParamsKey,uuid ,dfid,clientver,userid } = require('../util');
+
+module.exports = (params, useAxios) => {
+  const encrypt = cryptoAesEncrypt({ token: params.token || params.cookie?.token });
+  const dateTime = Date.now();
+  const pagesize = params.pagesize;
+  const tag = target ? `chat:${target}_${userid}` : undefined;
+  const target = params.target;
+  const filter = params.filter;
+  const dataMap = {
+    filter: filter,
+    dfid,
+    appid,
+    pagesize: pagesize,
+    mid,
+    clientver,
+    tag,
+    clienttime : dateTime,
+    signatrue: signParamsKey(dateTime),
+    userid,
+    uuid,
+    token: encrypt,
+
+  };
+
+return useAxios({
+    url: '/v3/msgtag/history',
+    encryptType: 'android',
+    method: 'GET',
+    data: dataMap,
+    cookie: params?.cookie,
+    headers: { 'x-router': 'msg.mobile.kugou.com' }
+  });
+
+}


### PR DESCRIPTION
feat: 列出私信消息历史
说明：这个接口可以查询与某位用户的消息历史记录
使用方法：
1. 调用`/user/follow`，找到要查看会话的用户id
2. 调用本接口`/message/history`，需要参数为target（要查看的用户id），pagesize（页数，默认为20），filter（未知，默认值为1）
3. 返回list的json数据
测试结果：返回2102错误代码，显示签名错误
补充信息：抓包时发现还传入了一个maxid，未知其生成原理。其实抓了两次，一次有，一次没有，但是两个接口都能返回list数据
目前核心问题：解决签名错误的问题，所以提交的是请求草案

<img width="2560" height="1568" alt="9Z`ZD831RL53JEDOFJ_9JPE" src="https://github.com/user-attachments/assets/d8721f8c-a9dc-46af-8f47-5b85f750fd2a" />

如果该接口目前的核心问题无法解决或该接口非必要，您可关闭该拉取请求