### PR TITLE
fix: 修复 Docker 构建权限并改用 pnpm 锁文件

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,5 +8,6 @@
 !/server.js
 !/package.json
 !/package-lock.json
+!/pnpm-lock.yaml
 !/index.js
 !/main.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,23 @@ FROM node:lts-alpine
 
 RUN apk add --no-cache tini
 
-ENV NODE_ENV production
+RUN corepack enable
 
-USER node
+ENV NODE_ENV=production
 
 WORKDIR /app
 
-COPY --chown=node:node . ./
+RUN chown node:node /app
 
-RUN yarn --network-timeout=100000
+COPY --chown=node:node package.json pnpm-lock.yaml ./
+
+USER node
+
+RUN pnpm install --prod --frozen-lockfile
+
+COPY --chown=node:node . ./
 
 EXPOSE 3000
 
-CMD [ "/sbin/tini", "--", "node", "app.js" ]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "app.js"]


### PR DESCRIPTION
## 背景

Dockerfile 貌似很久没维护了，我构建的时候会在安装依赖时报权限错误。

```sh
Step 7/9 : RUN yarn --network-timeout=100000
 ---> Running in 7d7ce3482d89
yarn install v1.22.22
info No lockfile found.
[1/5] Validating package.json...
[2/5] Resolving packages...
(node:1) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
(Use `node --trace-deprecation ...` to show where the warning was created)
warning pkg > prebuild-install@7.1.1: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
[3/5] Fetching packages...
[4/5] Linking dependencies...
error Error: EACCES: permission denied, mkdir '/app/node_modules'
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
The command '/bin/sh -c yarn --network-timeout=100000' returned a non-zero code: 1
```

我的 Docker 是 root 权限的，`WORKDIR` 默认会由 root 创建，即便是先通过 `USER` 切换到普通用户。

## 修复和优化

- 正确的做法应当是延迟切换到普通用户，并显式为目录授权。
- 我顺便将包管理换成了 pnpm，因为在部署时用锁文件可以增强可复现性，而仓库里貌似只有 pnpm 的锁文件？最起码 pnpm 也要更快。
- 单独 `COPY` 依赖文件到镜像里安装，利用 Docker 的分层缓存，这样依赖没变就不会触发镜像层重建。

## 结果

修复之后，在我的机子上可以构建成功。