### PR TITLE
feat：增加用户听歌时长

### DIFF
--- a/module/listen_history.js
+++ b/module/listen_history.js
@@ -1,0 +1,37 @@
+ //上传用户听歌时长
+const {  clientver, appid,signParamsKey,uuid, cryptoRSAEncrypt } = require('../util');
+    module.exports = (params, useAxios) => {
+        const userid = params?.userid || params?.cookie?.userid || 0;
+        const token = params?.token || params.cookie?.token || '';
+        const mid = params?.cookie?.KUGOU_API_MID;
+        const dateTime = Date.now();
+        const clienttime = Math.floor(Date.now() / 1000);
+        const p = cryptoRSAEncrypt({ clienttime, token }).toUpperCase();
+        const dataMap = {
+            mid,
+            diff_sec: "0",
+            y_type: "0",
+            type: "1",
+            uuid,
+            userid,
+            p,
+            appid,
+            d_sec: "0",
+            clientver,
+            clienttime,
+            m_type: "0",
+            key: signParamsKey(clienttime.toString())
+ 
+        }
+
+return useAxios({
+    baseURL: "http://userinfo.user.kugou.com",
+    url: '/v2/get_grade_info',
+    encryptType: 'android',
+    method: 'POST',
+    data: dataMap,
+    cookie: params?.cookie,
+    headers: { 'Host': 'userinfo.user.kugou.com' }
+  });
+
+}


### PR DESCRIPTION
改动说明：添加一个增加用户听歌时长的接口
改动原因：第三方客户端听歌以后，并没有增加听歌时长，等级也无法增长，因为无此接口。
参数简单说明：
1. p。是RSA加密的某些参数
2. diff_sec。听歌时间，按秒计算。
3. d_sec。未知。从此接口获取，传参需要参数为`p，appid，mid，clientver，clienttime，type（值为1），userid，uuid，key`。然后增加时长时需要传参，其值为获取值。
4. m_type.未知。抓包值为0
5. y_type.未知。其中一抓包值为0，但是抓包的其他数据包不为0。推测是切换了几首歌的计数值。
返回体说明：

<img width="1080" height="1417" alt="photo_2026-04-19_11-07-34" src="https://github.com/user-attachments/assets/8f9760a0-8f93-4028-a3f8-76b219475db9" />

1. p_grade_point。当前等级经验值
2. finish_precent。升级下一等级已完成百分比，
3. p_current_point。已获取经验值。
4. duration。听歌时长，单位为分钟。
5. p_grade。当前等级。
6. d_sec。未知。
7. p_next_grade_point。下一等级所需经验值。
8. p_next_grade。将升级的等级。
9. p_speed。听歌增长经验速度。

当前问题：
不知道p参数加密了什么，尝试`userid+token`失败，`userid+token+clienttime`还是失败

<img width="1280" height="547" alt="photo_2026-04-18_23-04-15" src="https://github.com/user-attachments/assets/87d48cbd-83ee-444b-8287-f72fb8196baf" />

改成当前这一版后，`data`返回`null`。错误代码相同，为20010
