### PR TITLE
feat-sound-recognize：添加听歌识曲

### DIFF
--- a/module/file_add.js
+++ b/module/file_add.js
@@ -1,0 +1,33 @@
+
+const {  signParamsKey,appid, mid ,clientver,clienttime,rsaEncrypt2, cryptoAesEncrypt } = require('../util'); 
+
+module.exports = (params, useAxios) => {
+  const userid = params?.token || params.cookie?.token || '0';
+  const token = params?.token || params.cookie?.token || '';
+  const paramsmap =  {
+      filename: params.fileHash || '',
+    };
+    
+    const aesEncrypt = cryptoAesEncrypt(paramsmap);
+    
+    const p = rsaEncrypt2({ aes: aesEncrypt.key, uid: userid, token }).toUpperCase();
+    
+    const dataMap = {
+      clienttime,
+      mid,
+      key: signParamsKey(clienttime.toString(), appid),
+      clientver,
+      appid,
+      p
+    }
+
+return useAxios({
+    baseURL:'https://mcloudservice.kugou.com',
+    url: '/v1/add_files',
+    encryptType: 'android',
+    method: 'POST',
+    data: dataMap,
+    cookie: params?.cookie,
+  });
+
+}

--- a/module/file_auth.js
+++ b/module/file_auth.js
@@ -1,0 +1,35 @@
+
+const { appid, mid ,clientver,signParamsKey, cryptoAesEncrypt } = require('../util');
+
+
+module.exports = (params, useAxios) => {
+  const clienttime = Math.floor(Date.now() / 1000);
+  const encrypt = cryptoAesEncrypt( params?.token || params.cookie?.token || '');
+  const paramsmap = {
+      method: "POST",
+      filename: params.fileHash || '',
+      extranet: "1",
+      bucket: "musicclound",
+      signatrue: signParamsKey(clienttime.toString(), appid),
+      clientver,
+      dfid:  params?.dfid || params.cookie?.dfid || '',
+      clienttime,
+      token: encrypt,
+      loginType: "1",
+      userid:  params?.userid || params.cookie?.userid || '0',
+      version: clientver,
+      appid,
+      mid,
+      buVerifyCode:"0"
+    }
+
+  return useAxios({
+    url: '/v1/upload/auth',
+    encryptType: 'android',
+    method: 'GET',
+    params: paramsmap,
+    cookie: params?.cookie,
+    headers: { 'x-router': 'bsstrackercdngz.kugou.com' }
+  });
+
+}

--- a/module/sound_recognize.js
+++ b/module/sound_recognize.js
@@ -1,0 +1,37 @@
+
+const { appid, clientver, uuid } = require('../util');
+
+module.exports = (params, useAxios) => {
+  const userid = params?.userid || params?.cookie?.userid || 0;
+  const mid = params?.cookie?.KUGOU_API_MID;
+  const token = params?.token || params?.cookie?.token || '';
+  const clienttime = Date.now();
+  
+  const dataMap = {
+    multi_result: 1,
+    request_type: 1,
+    area_code: 1,
+    mid,
+    fptype: 2,
+    userid,
+    uuid,
+    token,
+    dfid:  params?.dfid || params?.cookie?.dfid || '',
+    fpid: '2813539856812922955',
+    appid,
+    include_unpublish: 1,
+    clientver,
+    clienttime,
+    gitversion: 'cfe060d',
+    fpindex: 3
+  };
+
+  return useAxios({
+    baseURL:'http://fingerprint.service.kugou.com',
+    url: '/v3/music_trackid_second',
+    data: dataMap,
+    method: 'POST',
+    encryptType: 'android',
+    cookie: params?.cookie
+  });
+};

--- a/testpage/sound.html
+++ b/testpage/sound.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>声音识别测试页面</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+        }
+        .container {
+            border: 1px solid #ddd;
+            padding: 20px;
+            border-radius: 8px;
+        }
+        .form-group {
+            margin: 15px 0;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        input[type="text"] {
+            width: 100%;
+            padding: 8px;
+            box-sizing: border-box;
+            margin-bottom: 10px;
+        }
+        button {
+            padding: 10px 20px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            margin-top: 10px;
+            margin-right: 10px;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        button:disabled {
+            background-color: #ccc;
+            cursor: not-allowed;
+        }
+        .status {
+            margin-top: 20px;
+            padding: 15px;
+            background-color: #f5f5f5;
+            border-radius: 4px;
+        }
+        .loading {
+            color: #666;
+            margin-top: 10px;
+        }
+        .error {
+            color: #d32f2f;
+            margin-top: 10px;
+        }
+        .success {
+            color: #388e3c;
+            margin-top: 10px;
+        }
+        .info {
+            color: #1976d2;
+            margin-top: 10px;
+        }
+        pre {
+            background-color: #fff;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+            max-height: 300px;
+        }
+        .recording-indicator {
+            display: inline-block;
+            width: 12px;
+            height: 12px;
+            background-color: #d32f2f;
+            border-radius: 50%;
+            margin-right: 8px;
+            animation: pulse 1s infinite;
+        }
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>声音识别测试</h1>
+        
+        <div class="form-group">
+            <label for="token">Token：</label>
+            <input type="text" id="token" placeholder="输入 token 或从 URL 获取">
+        </div>
+
+        <div class="form-group">
+            <label for="userid">User ID：</label>
+            <input type="text" id="userid" placeholder="输入 userid 或从 URL 获取">
+        </div>
+
+        <div class="form-group">
+            <label for="dfid">DFID：</label>
+            <input type="text" id="dfid" placeholder="输入 dfid 或从 URL 获取">
+        </div>
+
+        <button id="startBtn" onclick="startRecording()">开始录制</button>
+        <button id="stopBtn" onclick="stopRecording()" disabled>停止录制</button>
+
+        <div class="status">
+            <div id="recordingStatus"></div>
+            <div id="loading" class="loading"></div>
+            <div id="error" class="error"></div>
+            <div id="success" class="success"></div>
+            <div id="info" class="info"></div>
+            <p><strong>识别结果：</strong></p>
+            <pre id="result"></pre>
+        </div>
+    </div>
+
+    <script>
+        let mediaRecorder = null;
+        let audioChunks = [];
+        let isRecording = false;
+        let recognitionInterval = null;
+        let audioBlob = null;
+        const API_URL = 'http://127.0.0.5:6521/sound/recognize';
+
+        // 从 URL 获取参数
+        function getUrlParams() {
+            const params = new URLSearchParams(window.location.search);
+            const cookie = params.get('cookie');
+            
+            if (cookie) {
+                const cookieParams = {};
+                cookie.split(';').forEach(pair => {
+                    const [key, value] = pair.split('=');
+                    if (key && value) {
+                        cookieParams[key.trim()] = value.trim();
+                    }
+                });
+                return cookieParams;
+            }
+            return {};
+        }
+
+        // 初始化参数
+        function initParams() {
+            const urlParams = getUrlParams();
+            
+            if (urlParams.token) document.getElementById('token').value = urlParams.token;
+            if (urlParams.userid) document.getElementById('userid').value = urlParams.userid;
+            if (urlParams.dfid) document.getElementById('dfid').value = urlParams.dfid;
+        }
+
+        function clearMessages() {
+            document.getElementById('loading').textContent = '';
+            document.getElementById('error').textContent = '';
+            document.getElementById('success').textContent = '';
+            document.getElementById('info').textContent = '';
+        }
+
+async function startRecording() {
+    const token = document.getElementById('token').value;
+    const userid = document.getElementById('userid').value;
+    const dfid = document.getElementById('dfid').value;
+
+    if (!token || !userid || !dfid) {
+        document.getElementById('error').textContent = '请填写所有参数';
+        return;
+    }
+
+    clearMessages();
+
+    try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        
+        const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+        const source = audioContext.createMediaStreamSource(stream);
+        const processor = audioContext.createScriptProcessor(4096, 1, 1);
+        
+        let audioData = [];
+
+        processor.onaudioprocess = (event) => {
+            const inputData = event.inputBuffer.getChannelData(0);
+            audioData.push(...inputData);
+        };
+
+        source.connect(processor);
+        processor.connect(audioContext.destination);
+
+        isRecording = true;
+        document.getElementById('startBtn').disabled = true;
+        document.getElementById('stopBtn').disabled = false;
+        document.getElementById('recordingStatus').innerHTML = '<span class="recording-indicator"></span>正在录制...';
+        document.getElementById('info').textContent = '录制已开始，每秒发送一次识别请求...';
+
+        // 每秒请求一次识别
+        recognitionInterval = setInterval(() => {
+            if (audioData.length > 0) {
+                recognizeAudio(token, userid, dfid, audioData);
+            }
+        }, 1000);
+
+        // 保存停止函数供后续使用
+        window.currentAudioContext = audioContext;
+        window.currentProcessor = processor;
+        window.currentSource = source;
+        window.currentStream = stream;
+
+    } catch (error) {
+        document.getElementById('error').textContent = `无法访问麦克风: ${error.message}`;
+    }
+}
+
+function stopRecording() {
+    if (isRecording) {
+        isRecording = false;
+        clearInterval(recognitionInterval);
+
+        if (window.currentStream) {
+            window.currentStream.getTracks().forEach(track => track.stop());
+        }
+        if (window.currentAudioContext) {
+            window.currentAudioContext.close();
+        }
+
+        document.getElementById('startBtn').disabled = false;
+        document.getElementById('stopBtn').disabled = true;
+        document.getElementById('recordingStatus').textContent = '录制已停止';
+        document.getElementById('info').textContent = '已停止录制和识别请求';
+    }
+}
+
+async function recognizeAudio(token, userid, dfid, audioData) {
+    if (!audioData || audioData.length === 0) {
+        return;
+    }
+
+    // 转换为 PCM 格式
+    const pcmData = new Int16Array(audioData.length);
+    for (let i = 0; i < audioData.length; i++) {
+        pcmData[i] = Math.max(-1, Math.min(1, audioData[i])) * 0x7FFF;
+    }
+
+    const formData = new FormData();
+    formData.append('audio', new Blob([pcmData], { type: 'audio/pcm' }), 'audio.pcm');
+
+    try {
+        const response = await fetch(API_URL, {
+            method: 'POST',
+            headers: {
+                'Authorization': `token=${token};userid=${userid};dfid=${dfid}`
+            },
+            body: formData
+        });
+
+        const data = await response.json();
+        document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+
+        if (data.status === 0 || data.error_code !== 0) {
+            document.getElementById('error').textContent = `识别失败: ${data.msg || '未知错误'}`;
+        } else {
+            document.getElementById('success').textContent = '识别成功';
+            stopRecording();
+        }
+    } catch (error) {
+        document.getElementById('error').textContent = `请求失败: ${error.message}`;
+    }
+}
+
+
+        // 页面加载时初始化参数
+        window.addEventListener('load', initParams);
+    </script>
+</body>
+</html>

--- a/testpage/upload.html
+++ b/testpage/upload.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>文件上传测试页面 - 上传文件</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/spark-md5/3.0.2/spark-md5.min.js"></script>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+        }
+        .container {
+            border: 1px solid #ddd;
+            padding: 20px;
+            border-radius: 8px;
+        }
+        .form-group {
+            margin: 15px 0;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        input[type="file"],
+        input[type="text"] {
+            width: 100%;
+            padding: 8px;
+            box-sizing: border-box;
+            margin-bottom: 10px;
+        }
+        button {
+            padding: 10px 20px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            margin-top: 10px;
+            margin-right: 10px;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        .result {
+            margin-top: 20px;
+            padding: 15px;
+            background-color: #f5f5f5;
+            border-radius: 4px;
+            word-break: break-all;
+        }
+        .loading {
+            color: #666;
+            margin-top: 10px;
+        }
+        .error {
+            color: #d32f2f;
+            margin-top: 10px;
+        }
+        .success {
+            color: #388e3c;
+            margin-top: 10px;
+        }
+        pre {
+            background-color: #fff;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>文件上传测试 - 上传文件</h1>
+        
+        <div class="form-group">
+            <label for="fileInput">选择文件：</label>
+            <input type="file" id="fileInput">
+        </div>
+
+        <div class="form-group">
+            <label for="token">Token：</label>
+            <input type="text" id="token" placeholder="输入 token">
+        </div>
+
+        <div class="form-group">
+            <label for="userid">User ID：</label>
+            <input type="text" id="userid" placeholder="输入 userid">
+        </div>
+
+        <div class="form-group">
+            <label for="dfid">DFID：</label>
+            <input type="text" id="dfid" placeholder="输入 dfid">
+        </div>
+
+        <button onclick="calculateHash()">计算 Hash</button>
+        <button onclick="uploadFile()">上传文件</button>
+
+        <div id="loading" class="loading"></div>
+        <div id="error" class="error"></div>
+        <div id="success" class="success"></div>
+        
+        <div id="result" class="result" style="display:none;">
+            <h3>结果：</h3>
+            <p><strong>文件名：</strong><span id="fileName"></span></p>
+            <p><strong>文件大小：</strong><span id="fileSize"></span> bytes</p>
+            <p><strong>MD5 Hash：</strong><span id="fileHash"></span></p>
+            <p><strong>后端响应：</strong></p>
+            <pre id="response"></pre>
+        </div>
+    </div>
+
+    <script>
+        let fileHash = null;
+        let selectedFile = null;
+        const API_URL = 'http://127.0.0.6:6521/file/add';
+
+        document.getElementById('fileInput').addEventListener('change', (e) => {
+            selectedFile = e.target.files[0];
+            fileHash = null;
+            document.getElementById('result').style.display = 'none';
+            clearMessages();
+        });
+
+        function clearMessages() {
+            document.getElementById('loading').textContent = '';
+            document.getElementById('error').textContent = '';
+            document.getElementById('success').textContent = '';
+        }
+
+        function calculateHash() {
+            if (!selectedFile) {
+                document.getElementById('error').textContent = '请先选择文件';
+                return;
+            }
+
+            clearMessages();
+            const loading = document.getElementById('loading');
+            loading.textContent = '正在计算 Hash...';
+
+            const reader = new FileReader();
+            const spark = new SparkMD5.ArrayBuffer();
+
+            reader.onload = (e) => {
+                spark.append(e.target.result);
+                fileHash = spark.end();
+                loading.textContent = '';
+                document.getElementById('success').textContent = 'Hash 计算完成';
+                showResult();
+            };
+
+            reader.onerror = () => {
+                document.getElementById('error').textContent = '读取文件失败';
+            };
+
+            reader.readAsArrayBuffer(selectedFile);
+        }
+
+        function showResult() {
+            document.getElementById('fileName').textContent = selectedFile.name;
+            document.getElementById('fileSize').textContent = selectedFile.size;
+            document.getElementById('fileHash').textContent = fileHash;
+            document.getElementById('result').style.display = 'block';
+        }
+
+        function uploadFile() {
+            if (!fileHash) {
+                document.getElementById('error').textContent = '请先计算 Hash';
+                return;
+            }
+
+            const token = document.getElementById('token').value;
+            const userid = document.getElementById('userid').value;
+            const dfid = document.getElementById('dfid').value;
+
+            if (!token || !userid || !dfid) {
+                document.getElementById('error').textContent = '请填写所有请求头参数';
+                return;
+            }
+
+            clearMessages();
+            const loading = document.getElementById('loading');
+            loading.textContent = '正在上传...';
+
+            const formData = new FormData();
+            formData.append('file', selectedFile);
+            formData.append('fileHash', fileHash);
+
+            const url = `${API_URL}?fileHash=${encodeURIComponent(fileHash)}`;
+
+            fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `token=${token};userid=${userid};dfid=${dfid}`
+                },
+                body: formData
+            })
+            .then(response => response.json())
+            .then(data => {
+                loading.textContent = '';
+                document.getElementById('response').textContent = JSON.stringify(data, null, 2);
+                
+                if (data.status === 0 || data.error_code !== 0) {
+                    document.getElementById('error').textContent = `上传失败: ${data.msg || '未知错误'}`;
+                } else {
+                    document.getElementById('success').textContent = '上传成功';
+                }
+                
+                document.getElementById('result').style.display = 'block';
+            })
+            .catch(error => {
+                loading.textContent = '';
+                document.getElementById('error').textContent = `上传失败: ${error.message}`;
+            });
+        }
+    </script>
+</body>
+</html>

--- a/testpage/uploadhash.html
+++ b/testpage/uploadhash.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>文件上传测试页面 - 上传Hash</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/spark-md5/3.0.2/spark-md5.min.js"></script>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+        }
+        .container {
+            border: 1px solid #ddd;
+            padding: 20px;
+            border-radius: 8px;
+        }
+        .form-group {
+            margin: 15px 0;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        input[type="file"],
+        input[type="text"] {
+            width: 100%;
+            padding: 8px;
+            box-sizing: border-box;
+            margin-bottom: 10px;
+        }
+        button {
+            padding: 10px 20px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            margin-top: 10px;
+            margin-right: 10px;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        .result {
+            margin-top: 20px;
+            padding: 15px;
+            background-color: #f5f5f5;
+            border-radius: 4px;
+            word-break: break-all;
+        }
+        .loading {
+            color: #666;
+            margin-top: 10px;
+        }
+        .error {
+            color: #d32f2f;
+            margin-top: 10px;
+        }
+        .success {
+            color: #388e3c;
+            margin-top: 10px;
+        }
+        pre {
+            background-color: #fff;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>文件上传测试</h1>
+        
+        <div class="form-group">
+            <label for="fileInput">选择文件：</label>
+            <input type="file" id="fileInput">
+        </div>
+
+        <div class="form-group">
+            <label for="token">Token：</label>
+            <input type="text" id="token" placeholder="输入 token">
+        </div>
+
+        <div class="form-group">
+            <label for="userid">User ID：</label>
+            <input type="text" id="userid" placeholder="输入 userid">
+        </div>
+
+        <div class="form-group">
+            <label for="dfid">DFID：</label>
+            <input type="text" id="dfid" placeholder="输入 dfid">
+        </div>
+
+        <button onclick="calculateHash()">计算 Hash</button>
+        <button onclick="uploadFile()">上传文件Hash</button>
+
+        <div id="loading" class="loading"></div>
+        <div id="error" class="error"></div>
+        <div id="success" class="success"></div>
+        
+        <div id="result" class="result" style="display:none;">
+            <h3>结果：</h3>
+            <p><strong>文件名：</strong><span id="fileName"></span></p>
+            <p><strong>文件大小：</strong><span id="fileSize"></span> bytes</p>
+            <p><strong>MD5 Hash：</strong><span id="fileHash"></span></p>
+            <p><strong>请求头：</strong></p>
+            <pre id="requestHeaders"></pre>
+            <p><strong>后端响应：</strong></p>
+            <pre id="response"></pre>
+        </div>
+    </div>
+
+    <script>
+        let fileHash = null;
+        let selectedFile = null;
+        const API_URL = 'http://127.0.0.5:6521/file/auth';
+
+        document.getElementById('fileInput').addEventListener('change', (e) => {
+            selectedFile = e.target.files[0];
+            fileHash = null;
+            document.getElementById('result').style.display = 'none';
+            clearMessages();
+        });
+
+        function clearMessages() {
+            document.getElementById('loading').textContent = '';
+            document.getElementById('error').textContent = '';
+            document.getElementById('success').textContent = '';
+        }
+
+        function calculateHash() {
+            if (!selectedFile) {
+                document.getElementById('error').textContent = '请先选择文件';
+                return;
+            }
+
+            clearMessages();
+            const loading = document.getElementById('loading');
+            loading.textContent = '正在计算 Hash...';
+
+            const reader = new FileReader();
+            const spark = new SparkMD5.ArrayBuffer();
+
+            reader.onload = (e) => {
+                spark.append(e.target.result);
+                fileHash = spark.end();
+                loading.textContent = '';
+                document.getElementById('success').textContent = 'Hash 计算完成';
+                showResult();
+            };
+
+            reader.onerror = () => {
+                document.getElementById('error').textContent = '读取文件失败';
+            };
+
+            reader.readAsArrayBuffer(selectedFile);
+        }
+
+        function showResult() {
+            const token = document.getElementById('token').value;
+            const userid = document.getElementById('userid').value;
+            const dfid = document.getElementById('dfid').value;
+
+            const headers = {
+                'Authorization': `token=${token};userid=${userid};dfid=${dfid}`,
+                'x-router': 'bsstrackercdngz.xxx.com'
+            };
+
+            document.getElementById('fileName').textContent = selectedFile.name;
+            document.getElementById('fileSize').textContent = selectedFile.size;
+            document.getElementById('fileHash').textContent = fileHash;
+            document.getElementById('requestHeaders').textContent = JSON.stringify(headers, null, 2);
+            document.getElementById('result').style.display = 'block';
+        }
+
+        function uploadFile() {
+            if (!fileHash) {
+                document.getElementById('error').textContent = '请先计算 Hash';
+                return;
+            }
+
+            const token = document.getElementById('token').value;
+            const userid = document.getElementById('userid').value;
+            const dfid = document.getElementById('dfid').value;
+
+            if (!token || !userid || !dfid) {
+                document.getElementById('error').textContent = '请填写所有请求头参数';
+                return;
+            }
+
+            clearMessages();
+            const loading = document.getElementById('loading');
+            loading.textContent = '正在上传...';
+
+            const params = new URLSearchParams();
+            params.append('fileHash', fileHash);
+
+            fetch(`${API_URL}?${params.toString()}`, {
+                method: 'GET',
+                headers: {
+                    'Authorization': `token=${token};userid=${userid};dfid=${dfid}`,
+                    'x-router': 'bsstrackercdngz.kugou.com'
+                }
+            })
+            .then(response => response.json())
+            .then(data => {
+                loading.textContent = '';
+                document.getElementById('response').textContent = JSON.stringify(data, null, 2);
+                
+                if (data.status === 0 || data.error_code !== 0) {
+                    document.getElementById('error').textContent = `上传失败: ${data.msg || '未知错误'}`;
+                } else {
+                    document.getElementById('success').textContent = '上传成功';
+                }
+                
+                document.getElementById('result').style.display = 'block';
+            })
+            .catch(error => {
+                loading.textContent = '';
+                document.getElementById('error').textContent = `上传失败: ${error.message}`;
+            });
+        }
+    </script>
+</body>
+</html>

--- a/testpage/uploadhash.html
+++ b/testpage/uploadhash.html
@@ -74,7 +74,7 @@
 </head>
 <body>
     <div class="container">
-        <h1>文件上传测试</h1>
+        <h1>文件上传测试- 上传Hash</h1>
         
         <div class="form-group">
             <label for="fileInput">选择文件：</label>
@@ -168,7 +168,7 @@
 
             const headers = {
                 'Authorization': `token=${token};userid=${userid};dfid=${dfid}`,
-                'x-router': 'bsstrackercdngz.xxx.com'
+                'x-router': 'bsstrackercdngz.kugou.com'
             };
 
             document.getElementById('fileName').textContent = selectedFile.name;


### PR DESCRIPTION
改动说明：添加听歌识曲（一不小心提交了未完成的云盘上传...）

文件结构说明：
file_auth.js 首次上传云盘需要先上传文件的MD5 Hash
file_add.js 这一步才是正式上传文件，二次上传相同文件似乎不需要上传Hash
sound_recognize.js 听歌识曲
`testpage/`

3个测试页分别是听歌识曲，上传文件，上传文件Hash

使用方法：打开测试页，运行后端，按页面操作即可


已知问题：

1. Hash值上传失败，奇怪的报错
```
{
  "status": 0,
  "data": "",
  "error_code": 20006,
  "error_msg": "err appid(srcappid) or clientver or mid or dfid"
}
```
2. 文件上传的主步骤的参数`p`构造还未成功
3. 听歌识曲接口如果`baseURL`用https协议会报500错误，原因未知
4. 听歌识曲接口使用http协议可以正常运行，但是上传音频会发生错误：
```
{
  "error_code": 20010,
  "status": 0,
  "data": "fpid is nil"
}
```
但是已经固定`fpid`参数，下次尝试随机生成

5. 没有在除听歌识曲以外的测试页添加从URL获取token，userid，dfid的功能，后续改进

补充说明：本地测试仍然在使用编译的二进制文件，可能出奇怪的问题，稍后使用docker构建镜像测试