### PR TITLE
Update docs：补充参数以防止搜索接口调用失败

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -877,6 +877,7 @@ fileids: 歌单中歌曲的 fileid，可多个,用逗号隔开
 `type`: 搜索类型；默认为单曲，special：歌单，lyric：歌词，song：单曲，album：专辑，author：歌手，mv：mv
 
 ⚠️ 注意：因接口问题，获取搜索结果需要在url后添加`cookie`认证信息或者`Set-cookie`，否则会返回 `error_code: 152`
+
 ⚠️ 注意：建议请求在所有搜索接口时添加认证信息防止调用失败！
 
 **接口地址：** `/search`

--- a/docs/README.md
+++ b/docs/README.md
@@ -876,6 +876,8 @@ fileids: 歌单中歌曲的 fileid，可多个,用逗号隔开
 
 `type`: 搜索类型；默认为单曲，special：歌单，lyric：歌词，song：单曲，album：专辑，author：歌手，mv：mv
 
+⚠️ 注意：因接口问题，获取搜索结果需要在url后添加'cookie'认证信息或者'Set-cookie'，否则会返回 `error_code: 152`
+
 **接口地址：** `/search`
 
 **调用例子：** `/search?keywords=海阔天空`

--- a/docs/README.md
+++ b/docs/README.md
@@ -880,7 +880,7 @@ fileids: 歌单中歌曲的 fileid，可多个,用逗号隔开
 
 **接口地址：** `/search`
 
-**调用例子：** `/search?keywords=海阔天空`，`/search?keywords==周杰伦&cookie=token=xxxx;userid=xxxx;dfid=xxxx`（必须携带认证信息）
+**调用例子：** `/search?keywords=海阔天空`，`/search?keywords=周杰伦&cookie=token=xxxx;userid=xxxx;dfid=xxxx`（必须携带认证信息）
 
 ### 默认搜索关键词
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -877,10 +877,11 @@ fileids: 歌单中歌曲的 fileid，可多个,用逗号隔开
 `type`: 搜索类型；默认为单曲，special：歌单，lyric：歌词，song：单曲，album：专辑，author：歌手，mv：mv
 
 ⚠️ 注意：因接口问题，获取搜索结果需要在url后添加`cookie`认证信息或者`Set-cookie`，否则会返回 `error_code: 152`
+⚠️ 注意：建议请求在所有搜索接口时添加认证信息防止调用失败！
 
 **接口地址：** `/search`
 
-**调用例子：** `/search?keywords=海阔天空`，`/search?keywords=周杰伦&cookie=token=xxxx;userid=xxxx;dfid=xxxx`（必须携带认证信息）
+**调用例子：** `/search?keywords=海阔天空`（错误示例），`/search?keywords=周杰伦&cookie=token=xxxx;userid=xxxx;dfid=xxxx`（必须携带认证信息）
 
 ### 默认搜索关键词
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -876,11 +876,11 @@ fileids: 歌单中歌曲的 fileid，可多个,用逗号隔开
 
 `type`: 搜索类型；默认为单曲，special：歌单，lyric：歌词，song：单曲，album：专辑，author：歌手，mv：mv
 
-⚠️ 注意：因接口问题，获取搜索结果需要在url后添加'cookie'认证信息或者'Set-cookie'，否则会返回 `error_code: 152`
+⚠️ 注意：因接口问题，获取搜索结果需要在url后添加`cookie`认证信息或者`Set-cookie`，否则会返回 `error_code: 152`
 
 **接口地址：** `/search`
 
-**调用例子：** `/search?keywords=海阔天空`
+**调用例子：** `/search?keywords=海阔天空`，`/search?keywords==周杰伦&cookie=token=xxxx;userid=xxxx;dfid=xxxx`（必须携带认证信息）
 
 ### 默认搜索关键词
 


### PR DESCRIPTION
**说明**：补充了搜索接口缺少的认证信息，防止调用时返回` "error_code": 152`
**关联issue：**#189 
**测试照：**

调用成功图：

<img width="2560" height="1568" alt="image" src="https://github.com/user-attachments/assets/60943843-5972-4ef6-97cc-38c1932e3375" />

不写认证信息导致失败图：

<img width="2560" height="1568" alt="image" src="https://github.com/user-attachments/assets/fce2055f-8fb2-444a-85a7-59c910a61fd9" />
