### PR TITLE
fix: 修复 cookie 缺失时读取 KUGOU_API_WEBGL 导致接口崩溃

### DIFF
--- a/util/request.js
+++ b/util/request.js
@@ -76,7 +76,7 @@ const createRequest = (options) => {
     const userid = options?.cookie?.userid || 0;           // 用户 ID
     const clienttime = Math.floor(Date.now() / 1000);     // 当前时间戳（秒）
     const ip = options?.realIP || options?.ip || '';       // 客户端 IP（用于 IP 透传）
-    const webglHash = options?.cookie.KUGOU_API_WEBGL;    // WebGL 指纹哈希
+    const webglHash = options?.cookie?.KUGOU_API_WEBGL;   // WebGL 指纹哈希
 
     // ========== 构建请求头 ==========
     // kg-rc / kg-thash / kg-rec / kg-rf: 酷狗内部标识头，用于服务端识别请求来源


### PR DESCRIPTION
## 问题
调用不传 cookie 的接口（如 video_url，MV 播放）时，request.js 抛出：
TypeError: Cannot read properties of undefined (reading 'KUGOU_API_WEBGL')

## 原因
util/request.js 读取 webglHash 时只用了一层可选链 `options?.cookie.KUGOU_API_WEBGL`，
当 options.cookie 为 undefined 时访问 .KUGOU_API_WEBGL 报错。
同文件其他字段（dfid/token/userid）均为 `options?.cookie?.xxx`，唯独此处遗漏。

## 修复
改为 `options?.cookie?.KUGOU_API_WEBGL`，与其他字段保持一致。cookie 缺失时 webglHash 为 undefined，后续 generateSimulate 可正常处理，逻辑不变。
