### PR TITLE
chore: 升级 typescript 版本至 5.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier": "^2.7.1",
     "ts-node": "^10.9.1",
     "tsdown": "^0.22.3",
-    "typescript": "^4.9.3"
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "axios": "^1.1.3",


### PR DESCRIPTION
安装依赖产生如下报错:

```
npm error ERESOLVE could not resolve
While resolving: tsdown@0.22.3
Found: typescript@4.9.5
peerOptional typescript@"^5.0.0 || ^6.0.0" from tsdown
```
原因:
tsdown@0.22.3 要求 TypeScript 5 或 6 ,导致依赖冲突

解决:
升级 typescript 版本至 5.9.3

结果:
编译构建正常通过