### PR TITLE
feat: 添加已购单曲/专辑接口

### DIFF
--- a/interface.d.ts
+++ b/interface.d.ts
@@ -2628,6 +2628,58 @@ export function song_ranking(params: SongRankingParams): Promise<ApiResponse>;
 export function song_ranking_filter(params: SongRankingFilterParams): Promise<ApiResponse>;
 
 // ============================================================
+//  导出函数 —— 已购单曲/专辑
+// ============================================================
+
+/** 已购单曲/专辑商品信息 */
+export interface PurchasedGoods {
+  /** 商品类型：audio 或 album */
+  type: 'audio' | 'album';
+  /** 商品 ID */
+  id: number;
+  /** 哈希值（单曲有，专辑为空） */
+  hash: string;
+  /** 商品名称（歌手 - 歌曲名 或 专辑名） */
+  name: string;
+  /** 过期时间（0 表示永不过期） */
+  expire: number;
+  /** 专辑 ID */
+  album_id: string;
+  /** 付费类型 */
+  pay_type: number;
+  /** 添加时间（Unix 时间戳） */
+  addtime: number;
+  /** 是否已发布 */
+  is_publish: number;
+  /** 专辑音频 ID（单曲有，专辑为 0） */
+  album_audio_id: number;
+  /** 歌手名（仅专辑） */
+  singer_name?: string;
+  /** 封面图片 URL（仅专辑） */
+  img?: string;
+}
+
+/** 已购单曲/专辑响应数据 */
+export interface PurchasedGoodsData {
+  /** 总数 */
+  total: number;
+  /** 商品列表 */
+  goods: PurchasedGoods[];
+}
+
+/**
+ * 获取已购单曲列表（需登录）
+ * @route /user/purchased/songs
+ */
+export function user_purchased_songs(params?: PaginatedParams): Promise<ApiResponse<PurchasedGoodsData>>;
+
+/**
+ * 获取已购专辑列表（需登录）
+ * @route /user/purchased/albums
+ */
+export function user_purchased_albums(params?: PaginatedParams): Promise<ApiResponse<PurchasedGoodsData>>;
+
+// ============================================================
 //  导出函数 —— 服务器管理（来自 server 模块）
 // ============================================================
 

--- a/module/user_purchased_albums.js
+++ b/module/user_purchased_albums.js
@@ -1,0 +1,25 @@
+// 已购专辑
+const { appid, clientver } = require('../util');
+
+module.exports = (params, useAxios) => {
+  const dataMap = {
+    appid,
+    clientver,
+    type: 'album',
+    vip: params?.cookie?.vip_type || 0,
+    token: params?.cookie?.token || '',
+    pagesize: params?.pagesize || 30,
+    userid: params?.cookie?.userid || 0,
+    page: params?.page || 1,
+    area_code: '1',
+  };
+
+  return useAxios({
+    url: '/v1/get_goods',
+    method: 'POST',
+    data: dataMap,
+    encryptType: 'android',
+    cookie: params?.cookie || {},
+    headers: { 'x-router': 'media.store.kugou.com' },
+  });
+};

--- a/module/user_purchased_songs.js
+++ b/module/user_purchased_songs.js
@@ -1,0 +1,26 @@
+// 已购单曲
+const { appid, clientver } = require('../util');
+
+module.exports = (params, useAxios) => {
+  const dataMap = {
+    appid,
+    clientver,
+    category: 'music',
+    type: 'kubi_audio',
+    vip: params?.cookie?.vip_type || 0,
+    token: params?.cookie?.token || '',
+    pagesize: params?.pagesize || 30,
+    userid: params?.cookie?.userid || 0,
+    page: params?.page || 1,
+    area_code: '1',
+  };
+
+  return useAxios({
+    url: '/v1/get_goods',
+    method: 'POST',
+    data: dataMap,
+    encryptType: 'android',
+    cookie: params?.cookie || {},
+    headers: { 'x-router': 'media.store.kugou.com' },
+  });
+};


### PR DESCRIPTION
## 功能说明

新增两个已购内容查询接口：

### 新增接口
- `GET /user/purchased/songs` - 获取已购单曲列表
- `GET /user/purchased/albums` - 获取已购专辑列表

### 主要变更
- 新增 `module/user_purchased_songs.js` - 已购单曲接口实现
- 新增 `module/user_purchased_albums.js` - 已购专辑接口实现
- 更新 `interface.d.ts` - 添加 PurchasedGoods 类型定义

### 请求参数
| 参数 | 类型 | 说明 |
|------|------|------|
| page | number | 页码，默认 1 |
| pagesize | number | 每页条数，默认 30 |

### 响应示例
```json
{
  "status": 1,
  "data": {
    "total": 2,
    "goods": [
      {
        "type": "audio",
        "id": 184659,
        "hash": "DC01CBBB77D98925BABBC8DFEF7C5D02",
        "name": "周杰伦 - 龙卷风",
        "album_id": "978031"
      }
    ]
  }
}
```

### 测试说明
- 需要用户登录（有效的 token 和 userid）
- 接口通过 `x-router` 头路由到 `media.store.kugou.com`