### PR TITLE
feat: add cloud file upload and delete support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -272,7 +272,7 @@ $ set HOST=127.0.0.1 && npm run dev
 
 #### 更新记录
 
-26-08-01：添加 `上传音乐到云盘` 接口
+26-08-01：添加 `上传音乐到云盘`、`删除用户云盘音乐` 接口
 
 26-05-20：更新曲谱相关接口
 
@@ -585,10 +585,54 @@ https://long.open.weixin.qq.com/connect/l/qrconnect?f=json&uuid=xxx 该接口直
 
 **调用例子：** `/user/cloud/url`
 
+### 删除用户云盘音乐
+
+说明：登录后调用此接口可以删除用户云盘中的音乐（需要登录）
+
+**必选参数：**
+
+`hash`: 音乐 hash，多个可用逗号分隔；也可使用 `hashes` 传数组。若已知云盘文件 ID，优先使用可选参数 `fileid` 和 `album_audio_id`
+
+**可选参数：**
+
+`clientver`: 覆盖客户端版本号，默认使用当前平台配置
+
+`appid`: 覆盖 appid，默认使用当前平台配置
+
+`fileid`: 云盘文件 ID（列表接口返回的 `kv_id`），多个可用逗号分隔；也可使用 `fileids` 传数组
+
+`kv_id`: `fileid` 别名
+
+`album_audio_id`: 专辑音频 ID（列表接口返回的 `album_audio_id`），多个可用逗号分隔；也可使用 `album_audio_ids` 传数组
+
+**接口地址：** `/user/cloud/del`
+
+**调用例子：** `/user/cloud/del?fileid=1&album_audio_id=123`
+
+### 云盘上传前曲库匹配
+
+说明：登录后调用此接口可以根据文件 hash 匹配曲库信息，用于上传前获取 `hash_std`、`audio_id`、`album_audio_id`
+
+**必选参数：**
+
+`hash`: 文件 hash（即文件 MD5），多个可用逗号分隔；也可通过请求体传入文件二进制数据自动计算
+
+**可选参数：**
+
+`album_audio_id`: 专辑音频 ID，已有时可辅助匹配，多个可用逗号分隔；也可使用 `album_audio_ids` 传数组
+
+`clientver`: 覆盖客户端版本号，默认使用当前平台配置
+
+`appid`: 覆盖 appid，默认使用当前平台配置
+
+**接口地址：** `/user/cloud/match`
+
+**调用例子：** `/user/cloud/match?hash=e1fe087ba28766b8c95239487a0e46dc`
+
 ### 上传音乐到云盘
 
 说明：登录后调用此接口可以将音乐文件上传到用户云盘，需通过请求体传入文件二进制数据（`Content-Type: application/octet-stream`）  
-可选参数建议传入，否则手机端无法正常播放。当audio_id传入时，服务端会匹配audio_id，若匹配到则使用匹配到的文件名，否则使用name
+默认会先根据文件 hash 调用曲库匹配接口，并将匹配到的 `hash_std`、`audio_id`、`album_audio_id` 写入云盘；手动传入这些参数时会优先使用手动值
 
 **必选参数：**
 
@@ -604,9 +648,13 @@ https://long.open.weixin.qq.com/connect/l/qrconnect?f=json&uuid=xxx 该接口直
 
 `author_name`: 歌手名
 
+`hash_std`: 曲库标准 hash，默认自动匹配
+
 `audio_id`: 音频 id，默认为 0
 
 `album_audio_id`: 专辑音频 id，默认为 0
+
+`auto_match`: 是否自动匹配曲库，默认 `1`；传 `0`、`false` 或 `no` 可关闭
 
 **接口地址：** `/user/cloud/upload`
 

--- a/interface.d.ts
+++ b/interface.d.ts
@@ -366,6 +366,92 @@ export interface UserCloudUrlParams extends CommonParams {
   album_audio_id?: string;
 }
 
+/** 删除用户云盘音乐参数 */
+export interface UserCloudDelParams extends CommonParams {
+  /** 音乐 hash，多个可用逗号分隔 */
+  hash?: string;
+  /** 音乐 hash 列表 */
+  hashes?: string[] | string;
+  /** 云盘文件 ID，多个可用逗号分隔 */
+  fileid?: number | string;
+  /** 云盘文件 ID 列表 */
+  fileids?: Array<number | string> | string;
+  /** 云盘文件 ID 别名 */
+  kv_id?: number | string;
+  /** 专辑音频 ID，列表接口返回 album_audio_id */
+  album_audio_id?: number | string;
+  /** 专辑音频 ID 列表 */
+  album_audio_ids?: Array<number | string> | string;
+  /** album_audio_id 别名 */
+  mix_id?: number | string;
+  /** album_audio_id 别名 */
+  mixid?: number | string;
+  /** 文件 hash 别名 */
+  filename?: string;
+  /** 覆盖客户端版本号，默认使用当前平台配置 */
+  clientver?: number | string;
+  /** 覆盖 appid，默认使用当前平台配置 */
+  appid?: number | string;
+}
+
+/** 云盘上传前曲库匹配参数 */
+export interface UserCloudMatchParams extends CommonParams {
+  /** 文件 hash（即文件 MD5），多个可用逗号分隔；不传时可通过请求体二进制自动计算 */
+  hash?: string;
+  /** 文件 hash 别名 */
+  filename?: string;
+  /** 专辑音频 ID，已有时可辅助匹配 */
+  album_audio_id?: number | string;
+  /** 专辑音频 ID 列表 */
+  album_audio_ids?: Array<number | string> | string;
+  /** album_audio_id 别名 */
+  mix_id?: number | string;
+  /** album_audio_id 别名 */
+  mixid?: number | string;
+  /** 覆盖客户端版本号，默认使用当前平台配置 */
+  clientver?: number | string;
+  /** 覆盖 appid，默认使用当前平台配置 */
+  appid?: number | string;
+}
+
+/** 上传音乐到用户云盘参数 */
+export interface UserCloudUploadParams extends CommonParams {
+  /** 文件 hash（即文件 MD5），默认根据请求体二进制自动计算 */
+  filename?: string;
+  /** 文件扩展名，默认 mp3 */
+  extendname?: string;
+  /** 云盘音乐显示名称 */
+  name?: string;
+  /** 歌曲名，不传 name 时用于拼接显示名称 */
+  track_name?: string;
+  /** 歌曲名别名 */
+  songname?: string;
+  /** 歌手名 */
+  author_name?: string;
+  /** 曲库标准 hash，不传时默认自动匹配 */
+  hash_std?: string;
+  /** 音频 id，不传时默认自动匹配 */
+  audio_id?: number | string;
+  /** 专辑音频 id，不传时默认自动匹配 */
+  album_audio_id?: number | string;
+  /** album_audio_id 别名 */
+  mix_id?: number | string;
+  /** album_audio_id 别名 */
+  mixid?: number | string;
+  /** 是否自动匹配曲库，默认 1；传 0/false/no 关闭 */
+  auto_match?: number | string | boolean;
+  /** 码率类型，默认 4 */
+  bitrate?: number | string;
+  /** 时长，毫秒 */
+  timelen?: number | string;
+  /** 云盘列表版本，默认 0 */
+  list_ver?: number | string;
+  /** 覆盖客户端版本号，默认使用当前平台配置 */
+  clientver?: number | string;
+  /** 覆盖 appid，默认使用当前平台配置 */
+  appid?: number | string;
+}
+
 /** 获取用户收藏的视频参数 */
 export interface UserVideoCollectParams extends PaginatedParams {}
 
@@ -1699,6 +1785,24 @@ export function user_cloud(params?: UserCloudParams): Promise<ApiResponse>;
  * @route /user/cloud/url
  */
 export function user_cloud_url(params: UserCloudUrlParams): Promise<ApiResponse>;
+
+/**
+ * 删除用户云盘音乐（需登录）
+ * @route /user/cloud/del
+ */
+export function user_cloud_del(params: UserCloudDelParams): Promise<ApiResponse>;
+
+/**
+ * 云盘上传前曲库匹配（需登录）
+ * @route /user/cloud/match
+ */
+export function user_cloud_match(params: UserCloudMatchParams): Promise<ApiResponse>;
+
+/**
+ * 上传音乐到云盘（需登录）
+ * @route /user/cloud/upload
+ */
+export function user_cloud_upload(params: UserCloudUploadParams): Promise<ApiResponse>;
 
 /**
  * 获取用户收藏的视频（需登录）

--- a/module/user_cloud_del.js
+++ b/module/user_cloud_del.js
@@ -1,0 +1,91 @@
+// 删除用户云盘音乐
+const { playlistAesEncrypt, playlistAesDecrypt, rsaEncrypt2, signParamsKey, clientver, appid } = require('../util');
+
+module.exports = (params, useAxios) => {
+  const answer = { status: 500, body: {}, cookie: [] };
+  return new Promise(async (resolve) => {
+    try {
+      const userid = String(params?.userid || params?.cookie?.userid || 0);
+      const token = params?.token || params?.cookie?.token || '';
+      const mid = params?.cookie?.KUGOU_API_MID;
+      const requestAppid = params?.appid || appid;
+      const requestClientver = params?.clientver || clientver;
+      const clienttime = Math.floor(Date.now() / 1000);
+
+      const fileids = []
+        .concat(params?.fileids || params?.fileid || params?.kv_ids || params?.kv_id || [])
+        .flatMap((item) => String(item).split(','))
+        .map((item) => item.trim())
+        .filter(Boolean);
+      const albumAudioIds = []
+        .concat(params?.album_audio_ids || params?.album_audio_id || [])
+        .flatMap((item) => String(item).split(','))
+        .map((item) => item.trim())
+        .filter(Boolean);
+      const hashes = []
+        .concat(params?.hashes || params?.hash || params?.filename || [])
+        .flatMap((item) => String(item).split(','))
+        .map((item) => item.trim())
+        .filter(Boolean);
+
+      if (!fileids.length && !hashes.length) throw new Error('请传入 fileid、kv_id、hash 或 hashes');
+
+      const dataMap = fileids.length
+        ? {
+            data: fileids.map((id, index) => ({
+              kv_id: Number(id) || id,
+              album_audio_id: Number(albumAudioIds[index] || albumAudioIds[0] || params?.mixid || params?.mix_id || 0),
+            })),
+          }
+        : { data: hashes };
+
+      const aesEncrypt = playlistAesEncrypt(dataMap);
+      const p = rsaEncrypt2({ aes: aesEncrypt.key, uid: userid, token }).toUpperCase();
+
+      const respone = await useAxios({
+        baseURL: 'https://mcloudservice.kugou.com',
+        url: '/v1/del_files',
+        params: {
+          clienttime,
+          mid,
+          key: signParamsKey(clienttime.toString(), requestAppid, requestClientver),
+          clientver: requestClientver,
+          appid: requestAppid,
+          p,
+        },
+        data: Buffer.from(aesEncrypt.str, 'base64'),
+        method: 'post',
+        encryptType: 'android',
+        responseType: 'arraybuffer',
+        cookie: params?.cookie || {},
+        clearDefaultParams: true,
+        notSignature: true,
+      });
+
+      try {
+        respone.body = playlistAesDecrypt({ str: respone.body.toString('base64'), key: aesEncrypt.key });
+      } catch (e) {
+        try {
+          respone.body = JSON.parse(respone.body.toString());
+        } catch (e2) {
+          respone.body = respone.body.toString();
+        }
+      }
+
+      resolve(respone);
+    } catch (error) {
+      console.log(error);
+      let upstream = error?.body?.msg?.response?.data;
+      if (upstream && Buffer.isBuffer(upstream)) upstream = upstream.toString();
+      answer.body = {
+        status: 0,
+        msg: upstream
+          ? typeof upstream === 'string'
+            ? upstream
+            : JSON.stringify(upstream)
+          : error?.body?.msg?.message || error?.message || String(error),
+      };
+      resolve(answer);
+    }
+  });
+};

--- a/module/user_cloud_match.js
+++ b/module/user_cloud_match.js
@@ -1,0 +1,96 @@
+// 云盘上传前曲库匹配
+const crypto = require('crypto');
+const { signParamsKey, appid, clientver } = require('../util');
+
+const fileMd5 = (buffer) => crypto.createHash('md5').update(buffer).digest('hex');
+
+const splitList = (value) =>
+  []
+    .concat(value || [])
+    .flatMap((item) => String(item).split(','))
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+const firstCandidate = (item) => (Array.isArray(item) ? item[0] : item);
+
+const normalizeMatch = (candidate) => {
+  if (!candidate || typeof candidate !== 'object') return null;
+  const audioInfo = candidate.audio_info || {};
+  const albumAudioId = Number(candidate.album_audio_id) || 0;
+  const audioId = Number(audioInfo.audio_id || candidate.audio_id) || 0;
+  const hashStd = audioInfo.hash || candidate.hash || '';
+  if (!albumAudioId && !audioId && !hashStd) return null;
+  return {
+    album_audio_id: albumAudioId,
+    audio_id: audioId,
+    hash_std: hashStd,
+    hash: hashStd,
+    author_name: candidate.author_name || '',
+    audio_name: candidate.ori_audio_name || candidate.audio_name || candidate.songname || '',
+    suffix_audio_name: candidate.suffix_audio_name || '',
+    album_info: candidate.album_info || null,
+    raw: candidate,
+  };
+};
+
+module.exports = (params, useAxios) => {
+  const answer = { status: 500, body: {}, cookie: [] };
+  return new Promise(async (resolve) => {
+    try {
+      const requestAppid = params?.appid || appid;
+      const requestClientver = params?.clientver || clientver;
+      const clienttime = Math.floor(Date.now() / 1000);
+      const hashes = splitList(params?.hash || params?.filename);
+      if (!hashes.length && params?.data?.length) hashes.push(fileMd5(params.data).toLowerCase());
+      if (!hashes.length) throw new Error('请传入 hash，或通过请求体传入文件二进制数据');
+
+      const albumAudioIds = splitList(params?.album_audio_ids || params?.album_audio_id || params?.mixid || params?.mix_id);
+      const data = hashes.map((hash, index) => {
+        const item = { hash: String(hash).toLowerCase() };
+        const albumAudioId = albumAudioIds[index] || albumAudioIds[0];
+        if (Number(albumAudioId) > 0) item.album_audio_id = String(albumAudioId);
+        return item;
+      });
+
+      const dataMap = {
+        appid: requestAppid,
+        clienttime,
+        clientver: requestClientver,
+        data,
+        dfid: params?.cookie?.dfid || params?.dfid || '-',
+        key: signParamsKey(clienttime.toString(), requestAppid, requestClientver),
+        mid: params?.cookie?.KUGOU_API_MID || params?.mid || '',
+        show_privilege: 0,
+        show_author_alias: 0,
+        show_rel_album_audio_info: 0,
+        show_remarks: 0,
+      };
+
+      const respone = await useAxios({
+        baseURL: 'http://kmr.service.kugou.com',
+        url: '/v2/album_audio/audio',
+        method: 'POST',
+        data: dataMap,
+        encryptType: 'android',
+        cookie: params?.cookie || {},
+        clearDefaultParams: true,
+        notSignature: true,
+        headers: { 'x-router': 'kmr.service.kugou.com', 'Content-Type': 'application/json' },
+      });
+
+      if (respone?.body?.status === 1 && Array.isArray(respone.body.data)) {
+        respone.body.match_list = respone.body.data.map((item) => normalizeMatch(firstCandidate(item))).filter(Boolean);
+        respone.body.match = respone.body.match_list[0] || null;
+      }
+
+      resolve(respone);
+    } catch (error) {
+      console.log(error);
+      answer.body = {
+        status: 0,
+        msg: error?.body?.msg?.message || error?.message || String(error),
+      };
+      resolve(answer);
+    }
+  });
+};

--- a/module/user_cloud_upload.js
+++ b/module/user_cloud_upload.js
@@ -1,13 +1,53 @@
 // 上传音乐文件到用户云盘
 // 流程：获取授权 → 初始化分片上传 → 上传分片 → 完成上传 → 添加文件到云盘
-// add_files 请求体结构来自 APK 逆向（com.kugou.android.musiccloud.a.a）
+// add_files 请求体结构与客户端云盘请求保持一致
 const axios = require('axios');
 const crypto = require('crypto');
-const { playlistAesEncrypt, playlistAesDecrypt, rsaEncrypt2, signParamsKey, clientver, appid } = require('../util');
+const {
+  playlistAesEncrypt,
+  playlistAesDecrypt,
+  rsaEncrypt2,
+  signParamsKey,
+  signatureAndroidParams,
+  cryptoMd5,
+  clientver,
+  appid,
+} = require('../util');
 const { resolveProxy } = require('../util/runtime');
+const userCloudMatch = require('./user_cloud_match');
 
 // 计算文件内容的 MD5（crypto-js 的 cryptoMd5 对 Buffer 会执行 JSON 序列化，不能用于文件）
 const fileMd5 = (buffer) => crypto.createHash('md5').update(buffer).digest('hex');
+const bssVerifyCode = (bucket, requestAppid) => cryptoMd5(`${requestAppid}${bucket}8ae10344e9738dcb`);
+const boolParam = (value, defaultValue = true) => {
+  if (value === undefined || value === null || value === '') return defaultValue;
+  return !['0', 'false', 'no'].includes(String(value).toLowerCase());
+};
+const firstCandidate = (item) => (Array.isArray(item) ? item[0] : item);
+const normalizeMatch = (candidate) => {
+  if (!candidate || typeof candidate !== 'object') return null;
+  const audioInfo = candidate.audio_info || {};
+  const albumAudioId = Number(candidate.album_audio_id) || 0;
+  const audioId = Number(audioInfo.audio_id || candidate.audio_id) || 0;
+  const hashStd = audioInfo.hash || candidate.hash || '';
+  if (!albumAudioId && !audioId && !hashStd) return null;
+  return {
+    album_audio_id: albumAudioId,
+    audio_id: audioId,
+    hash_std: hashStd,
+    author_name: candidate.author_name || '',
+    audio_name: candidate.ori_audio_name || candidate.audio_name || candidate.songname || '',
+    suffix_audio_name: candidate.suffix_audio_name || '',
+    raw: candidate,
+  };
+};
+const extractMatch = (body) => {
+  if (body?.match) return body.match;
+  if (Array.isArray(body?.match_list) && body.match_list.length) return body.match_list[0];
+  if (Array.isArray(body?.data) && body.data.length) return normalizeMatch(firstCandidate(body.data[0]));
+  return null;
+};
+const withProtocol = (host) => (/^https?:\/\//i.test(host || '') ? host : `http://${host}`);
 
 module.exports = (params, useAxios) => {
   const answer = { status: 500, body: {}, cookie: [] };
@@ -16,7 +56,11 @@ module.exports = (params, useAxios) => {
       // userid 必须为字符串（p 参数 RSA 加密时服务端校验 uid 类型）
       const userid = String(params?.userid || params?.cookie?.userid || 0);
       const token = params?.token || params?.cookie?.token || '';
-      const mid = params?.cookie?.KUGOU_API_MID;
+      const mid = params?.cookie?.KUGOU_API_MID || params?.mid || '';
+      const dfid = params?.cookie?.dfid || params?.dfid || '-';
+      const uuid = params?.cookie?.KUGOU_API_GUID || params?.uuid || '-';
+      const requestAppid = params?.appid || appid;
+      const requestClientver = params?.clientver || clientver;
       const clienttime = Math.floor(Date.now() / 1000);
 
       // 文件数据（由 HTTP 层接收的二进制 body 传入）
@@ -27,17 +71,44 @@ module.exports = (params, useAxios) => {
       const filename = String(params?.filename || fileMd5(fileData)).toLowerCase();
       // 扩展名（自动去掉点号）
       const extendname = String(params?.extendname || 'mp3').replace(/^\./, '');
-      // 歌手名与显示名称
-      const author_name = params?.author_name || '';
-      const name = params?.name || `${author_name ? `${author_name} - ` : ''}${filename}.${extendname}`;
       const bucket = 'musicclound';
-      const version = clientver;
+      const version = requestClientver;
+      let matchInfo = null;
+      const needMatch =
+        boolParam(params?.auto_match, true) &&
+        !(params?.hash_std && params?.audio_id && (params?.album_audio_id || params?.mixid || params?.mix_id));
+
+      if (needMatch) {
+        const matchRes = await userCloudMatch(
+          {
+            ...params,
+            data: undefined,
+            hash: filename,
+            appid: requestAppid,
+            clientver: requestClientver,
+          },
+          useAxios
+        );
+        if (matchRes?.body?.status === 1) matchInfo = extractMatch(matchRes.body);
+      }
+
+      const hashStd = String(params?.hash_std || matchInfo?.hash_std || filename).toLowerCase();
+      const audioId = Number(params?.audio_id || matchInfo?.audio_id) || 0;
+      const albumAudioId = Number(params?.album_audio_id || params?.mixid || params?.mix_id || matchInfo?.album_audio_id) || 0;
+      const author_name = params?.author_name || matchInfo?.author_name || '';
+      const trackName = params?.track_name || params?.songname || matchInfo?.audio_name || filename;
+      const name = params?.name || `${author_name ? `${author_name} - ` : ''}${trackName}.${extendname}`;
+
+      const signBssParams = (paramsMap) => {
+        paramsMap.signature = signatureAndroidParams(paramsMap, '');
+        return paramsMap;
+      };
 
       // 原生 axios 请求（步骤 1-4 不需要签名，尽量贴近抓包）
       const http = (options) => {
         const proxyConfig = resolveProxy();
         const headers = {
-          'User-Agent': 'Android15-1070-10672-201-0-wifi',
+          'User-Agent': `Android15-1070-${requestClientver}-201-0-wifi`,
           'KG-RC': '1',
           'KG-Rec': '1',
           // 每次请求生成随机的 KG-THash（模拟客户端行为，固定 7 位 hex）
@@ -50,34 +121,87 @@ module.exports = (params, useAxios) => {
       };
 
       // ========== 步骤1 获取上传授权 ==========
+      const authParams = signBssParams({
+        bucket,
+        filename,
+        method: 'POST',
+        loginType: token && userid !== '0' ? 1 : 0,
+        buVerifyCode: bssVerifyCode(bucket, requestAppid),
+        extranet: 1,
+        userid,
+        token,
+        version,
+        dfid,
+        mid,
+        uuid,
+        appid: requestAppid,
+        clientver: requestClientver,
+        clienttime: Math.floor(Date.now() / 1000),
+      });
       const authRes = await http({
         method: 'get',
-        url: 'http://bssulbig.kugou.com/v2/authorization',
-        params: { version, userid, filename, token, appid, method: 'POST', bucket },
+        url: 'https://gateway.kugou.com/bsstrackercdngz/v1/upload/auth',
+        params: authParams,
       });
       const authorization = authRes?.data?.data?.authorization;
       if (!authorization) throw new Error(JSON.stringify(authRes?.data) || '获取授权失败');
 
       // ========== 步骤2 初始化分片上传 ==========
+      const initParams = signBssParams({
+        bucket,
+        filename,
+        ssl: 1,
+        extendname,
+        version,
+        userid,
+        token,
+        authorization,
+        dfid,
+        mid,
+        uuid,
+        appid: requestAppid,
+        clientver: requestClientver,
+        clienttime: Math.floor(Date.now() / 1000),
+      });
       const initRes = await http({
         method: 'post',
-        url: 'http://bssulbig.kugou.com/multipart/initiate/music',
-        params: { version, extendname, userid, filename, appid, bucket },
+        url: 'http://bssulbig.kugou.com/v2/multipart/initiate/music',
+        params: initParams,
         headers: { Authorization: authorization },
       });
-      const { external_host, upload_id } = initRes?.data?.data || {};
+      const initData = initRes?.data?.data || {};
+      const { external_host, upload_id } = initData;
+      let bssFileHash = initData['x-bss-filename'] || filename;
 
       // 秒传分支：upload_id 为空且返回 x-bss-hash 说明文件已在服务器，跳过步骤3/4
       if (upload_id) {
-        // ========== 步骤3 上传分片（默认 4MB 一片） ==========
-        const partSize = 1024 * 1024 * 4;
+        if (!external_host) throw new Error(JSON.stringify(initRes?.data) || '初始化上传失败');
+        // ========== 步骤3 上传分片（默认 1MB 一片） ==========
+        const partSize = 1024 * 1024;
         const partCount = Math.max(1, Math.ceil(fileData.length / partSize));
         for (let i = 0; i < partCount; i++) {
           const part = fileData.slice(i * partSize, (i + 1) * partSize);
+          const uploadParams = signBssParams({
+            bucket,
+            authorization,
+            filename,
+            partnumber: i + 1,
+            upload_id,
+            body_empty: 1,
+            version,
+            userid,
+            token,
+            dfid,
+            mid,
+            uuid,
+            appid: requestAppid,
+            clientver: requestClientver,
+            clienttime: Math.floor(Date.now() / 1000),
+          });
           const uploadRes = await http({
             method: 'post',
-            url: `http://${external_host}/multipart/upload`,
-            params: { version, userid, filename, appid, upload_id, partnumber: i + 1, bucket },
+            url: `${withProtocol(external_host)}/v3/multipart/upload`,
+            params: uploadParams,
             headers: { Authorization: authorization, 'Content-Type': 'application/octet-stream' },
             data: part,
           });
@@ -85,17 +209,36 @@ module.exports = (params, useAxios) => {
         }
 
         // ========== 步骤4 完成上传 ==========
+        const completeParams = signBssParams({
+          bucket,
+          authorization,
+          filename,
+          partnumber: partCount,
+          upload_id,
+          md5: filename,
+          version,
+          userid,
+          token,
+          if_id3: 1,
+          dfid,
+          mid,
+          uuid,
+          appid: requestAppid,
+          clientver: requestClientver,
+          clienttime: Math.floor(Date.now() / 1000),
+        });
         const completeRes = await http({
           method: 'post',
-          url: `http://${external_host}/multipart/complete`,
-          params: { filename, bucket, if_id3: 1, upload_id, userid, md5: filename, version, appid, partnumber: partCount },
+          url: `${withProtocol(external_host)}/v3/multipart/complete`,
+          params: completeParams,
           headers: { Authorization: authorization },
         });
         if (completeRes?.data?.status !== 1) throw new Error(JSON.stringify(completeRes?.data) || '完成上传失败');
+        bssFileHash = completeRes?.data?.data?.['x-bss-filename'] || bssFileHash;
       }
 
       // ========== 步骤5 添加文件到云盘（AES 加密 body + RSA 加密密钥） ==========
-      // 请求体结构来自 APK：data 数组（所有字段必需）+ list_ver
+      // 请求体结构：data 数组（所有字段必需）+ list_ver
       // 数字字段必须为 number 类型（query 传入时为字符串，需转换，否则服务端返回 500）
       const aesEncrypt = playlistAesEncrypt({
         data: [
@@ -103,11 +246,11 @@ module.exports = (params, useAxios) => {
             name,
             ext: extendname,
             author_name,
-            hash: filename,
-            hash_std: filename,
-            audio_id: Number(params?.audio_id) || 0,
+            hash: bssFileHash,
+            hash_std: hashStd,
+            audio_id: audioId,
             bitrate: Number(params?.bitrate) || 4,
-            album_audio_id: Number(params?.album_audio_id) || 0,
+            album_audio_id: albumAudioId,
             size: fileData.length,
             timelen: Number(params?.timelen) || 0,
           },
@@ -122,9 +265,9 @@ module.exports = (params, useAxios) => {
         params: {
           clienttime,
           mid,
-          key: signParamsKey(clienttime.toString(), appid),
-          clientver,
-          appid,
+          key: signParamsKey(clienttime.toString(), requestAppid, requestClientver),
+          clientver: requestClientver,
+          appid: requestAppid,
           p,
         },
         data: Buffer.from(aesEncrypt.str, 'base64'),
@@ -152,7 +295,12 @@ module.exports = (params, useAxios) => {
         authorization,
         external_host,
         upload_id,
-        hash: filename,
+        hash: bssFileHash,
+        local_hash: filename,
+        hash_std: hashStd,
+        audio_id: audioId,
+        album_audio_id: albumAudioId,
+        matched: Boolean(matchInfo),
         filesize: fileData.length,
       };
 


### PR DESCRIPTION
## 变更内容

- 新增用户云盘删除接口 `/user/cloud/del`
- 新增云盘上传前曲库匹配接口 `/user/cloud/match`
- 完善 `/user/cloud/upload` 上传流程：
  - 上传前默认根据文件 MD5 匹配曲库信息
  - 自动写入 `hash_std`、`audio_id`、`album_audio_id`
  - 支持秒传、分片上传、完成上传后添加到云盘
- 补充 TypeScript 类型声明和文档说明

## 测试

- 使用 `platform=lite` 实测上传 `有何不可 - 许嵩.flac`
- 上传返回 `status=1`
- 云盘列表确认新增文件，返回 `kv_id=23`
- 调用删除接口返回 `status=1`
- 删除后复查云盘列表，文件不存在
- 执行语法检查：
  - `node --check module/user_cloud_upload.js`
  - `node --check module/user_cloud_match.js`
  - `node --check module/user_cloud_del.js`