### PR TITLE
fix: require cloud file id for delete

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -591,15 +591,13 @@ https://long.open.weixin.qq.com/connect/l/qrconnect?f=json&uuid=xxx 该接口直
 
 **必选参数：**
 
-`hash`: 音乐 hash，多个可用逗号分隔；也可使用 `hashes` 传数组。若已知云盘文件 ID，优先使用可选参数 `fileid` 和 `album_audio_id`
+`fileid`: 云盘文件 ID（列表接口返回的 `kv_id`），多个可用逗号分隔；也可使用 `fileids` 传数组
 
 **可选参数：**
 
 `clientver`: 覆盖客户端版本号，默认使用当前平台配置
 
 `appid`: 覆盖 appid，默认使用当前平台配置
-
-`fileid`: 云盘文件 ID（列表接口返回的 `kv_id`），多个可用逗号分隔；也可使用 `fileids` 传数组
 
 `kv_id`: `fileid` 别名
 

--- a/interface.d.ts
+++ b/interface.d.ts
@@ -368,10 +368,6 @@ export interface UserCloudUrlParams extends CommonParams {
 
 /** 删除用户云盘音乐参数 */
 export interface UserCloudDelParams extends CommonParams {
-  /** 音乐 hash，多个可用逗号分隔 */
-  hash?: string;
-  /** 音乐 hash 列表 */
-  hashes?: string[] | string;
   /** 云盘文件 ID，多个可用逗号分隔 */
   fileid?: number | string;
   /** 云盘文件 ID 列表 */
@@ -386,8 +382,6 @@ export interface UserCloudDelParams extends CommonParams {
   mix_id?: number | string;
   /** album_audio_id 别名 */
   mixid?: number | string;
-  /** 文件 hash 别名 */
-  filename?: string;
   /** 覆盖客户端版本号，默认使用当前平台配置 */
   clientver?: number | string;
   /** 覆盖 appid，默认使用当前平台配置 */

--- a/module/user_cloud_del.js
+++ b/module/user_cloud_del.js
@@ -1,6 +1,24 @@
 // 删除用户云盘音乐
 const { playlistAesEncrypt, playlistAesDecrypt, rsaEncrypt2, signParamsKey, clientver, appid } = require('../util');
 
+const splitList = (value) =>
+  []
+    .concat(value || [])
+    .flatMap((item) => {
+      if (Array.isArray(item)) return item;
+      const text = String(item).trim();
+      if (!text) return [];
+      if (text.startsWith('[') && text.endsWith(']')) {
+        try {
+          const parsed = JSON.parse(text);
+          if (Array.isArray(parsed)) return parsed;
+        } catch (e) {}
+      }
+      return text.split(',');
+    })
+    .map((item) => String(item).trim())
+    .filter(Boolean);
+
 module.exports = (params, useAxios) => {
   const answer = { status: 500, body: {}, cookie: [] };
   return new Promise(async (resolve) => {
@@ -12,32 +30,19 @@ module.exports = (params, useAxios) => {
       const requestClientver = params?.clientver || clientver;
       const clienttime = Math.floor(Date.now() / 1000);
 
-      const fileids = []
-        .concat(params?.fileids || params?.fileid || params?.kv_ids || params?.kv_id || [])
-        .flatMap((item) => String(item).split(','))
-        .map((item) => item.trim())
-        .filter(Boolean);
-      const albumAudioIds = []
-        .concat(params?.album_audio_ids || params?.album_audio_id || [])
-        .flatMap((item) => String(item).split(','))
-        .map((item) => item.trim())
-        .filter(Boolean);
-      const hashes = []
-        .concat(params?.hashes || params?.hash || params?.filename || [])
-        .flatMap((item) => String(item).split(','))
-        .map((item) => item.trim())
-        .filter(Boolean);
+      const fileids = splitList(params?.fileids || params?.fileid || params?.kv_ids || params?.kv_id);
+      const albumAudioIds = splitList(params?.album_audio_ids || params?.album_audio_id);
 
-      if (!fileids.length && !hashes.length) throw new Error('请传入 fileid、kv_id、hash 或 hashes');
+      if (!fileids.length) {
+        throw new Error('请传入 fileid 或 kv_id');
+      }
 
-      const dataMap = fileids.length
-        ? {
-            data: fileids.map((id, index) => ({
-              kv_id: Number(id) || id,
-              album_audio_id: Number(albumAudioIds[index] || albumAudioIds[0] || params?.mixid || params?.mix_id || 0),
-            })),
-          }
-        : { data: hashes };
+      const dataMap = {
+        data: fileids.map((id, index) => ({
+          kv_id: Number(id) || id,
+          album_audio_id: Number(albumAudioIds[index] || albumAudioIds[0] || params?.mixid || params?.mix_id || 0),
+        })),
+      };
 
       const aesEncrypt = playlistAesEncrypt(dataMap);
       const p = rsaEncrypt2({ aes: aesEncrypt.key, uid: userid, token }).toUpperCase();


### PR DESCRIPTION
## 变更内容

- 修正 `/user/cloud/del` 删除参数
- 移除按 `hash` / `hashes` / `filename` 删除云盘文件的支持
- 删除请求改为仅使用云盘列表返回的 `kv_id`（接口参数 `fileid` / `kv_id`）组包
- 同步更新 TypeScript 类型声明和 README 文档

## 背景说明

云盘删除接口实际需要使用 `/user/cloud` 列表返回的云盘文件 ID（`kv_id`）进行删除。按 `hash` 删除会返回 `status=0` / `error_code=20010`，因此移除相关参数说明，避免调用方误用。

## 测试

- 执行语法检查：
  - `node --check module/user_cloud_del.js`