### PR TITLE
feat: 新增听歌等级信息查询与时长上报接口

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -164,6 +164,7 @@
 135. [`获取已购单曲`](#获取已购单曲)
 136. [`获取已购专辑`](#获取已购专辑)
 137. [`上传音乐到云盘`](#上传音乐到云盘)
+138. [`获取听歌等级信息`](#获取听歌等级信息)
 
 ### 安装
 
@@ -2571,6 +2572,63 @@ const res = await fetch('/audio/match', {
 **接口地址：** `/user/purchased/albums`
 
 **调用例子：** `/user/purchased/albums`
+
+### 获取听歌等级信息
+
+说明：获取并上报用户听歌等级信息（听歌时长），登录后调用。支持两种调用方式：
+
+- **查询**（默认）：返回服务器当前累计听歌时长、等级与积分
+- **上报**：传入 `d_sec`（本地累计听歌秒数）与 `diff_sec`（本次新增秒数），同步本地累计时长
+
+> **平台限制**：本接口为概念版（lite）客户端协议，仅 `platform=lite` 下上报有效；
+> 标准版账号（不配置 `platform`）可查询，但上报不会记账（服务端静默忽略）。
+
+**必选参数（登录态）：**
+
+`cookie`：登录凭证，需包含 `token`、`userid`，建议同时包含 `mid`、`dfid`
+
+**可选参数：**
+
+`uuid`：设备 UUID，默认为 `-`
+
+`type`：类型，默认为 `1`
+
+**上报参数：**
+
+`d_sec`：本地累计听歌秒数（须大于等于服务器当前值）
+
+`diff_sec`：本次新增秒数，请按正常听歌节奏调用
+
+`y_type`：年份类型，默认为 `0`
+
+`m_type`：音乐类型，默认为 `0`
+
+**接口地址：** `/user/grade/info`
+
+**调用例子：**
+
+查询：`/user/grade/info?cookie=token%3Dxxx%3Buserid%3D123`
+
+上报：`/user/grade/info?cookie=token%3Dxxx%3Buserid%3D123&d_sec=123456&diff_sec=600&uuid=xxx`
+
+**返回示例：**
+
+```json
+{
+  "status": 1,
+  "error_code": 0,
+  "data": {
+    "d_sec": 125755,
+    "duration": 2095,
+    "p_grade": 3,
+    "p_current_point": 3809,
+    "p_grade_point": 3000,
+    "p_next_grade": 4,
+    "p_next_grade_point": 6000,
+    "servertime": "2026-08-05 23:10:40"
+  }
+}
+```
 
 ## License
 

--- a/module/user_grade_info.js
+++ b/module/user_grade_info.js
@@ -1,0 +1,93 @@
+// 酷狗听歌等级信息查询与听歌时长上报
+//
+// 两种模式（与官方客户端行为一致）：
+//  1. 查询模式（默认）：返回服务器当前累计听歌时长（d_sec）、等级（p_grade）、积分等
+//  2. 上报模式：传入 d_sec + diff_sec，同步本地累计听歌时长
+//     d_sec    本地累计听歌秒数（须 >= 服务器当前值）
+//     diff_sec 上次同步后的新增秒数
+//     md5      = MD5(d_sec + diff_sec + y_type + m_type)
+//
+// 说明：本协议为概念版（lite）客户端用户等级体系，标准版账号走该协议上报不会被记账；
+// 请在 lite 平台（platform=lite）下使用。服务器按真实时间记账（增量受距上次上报时间约束），
+// 请按正常听歌节奏调用。
+
+const crypto = require('crypto');
+const { cryptoRSAEncrypt, publicLiteRasKey, publicRasKey } = require('../util');
+const { appid, clientver, liteAppid, liteClientver } = require('../util/config.json');
+
+// 平台签名盐值与 RSA 公钥（与 util/helper.js、util/crypto.js 双平台配置保持一致）
+const APPKEY_MAP = {
+  lite: 'LnT6xpN3khm36zse0QzvmgTZ3waWdRSA',
+  standard: 'OIlwieks28dk2k092lksi2UIkp',
+};
+
+module.exports = (params, useAxios) => {
+  const isLite = process.env.platform === 'lite';
+  const token = params?.token || params?.cookie?.token || '';
+  const userid = Number(params?.userid || params?.cookie?.userid || 0);
+  const mid = params?.mid || params?.cookie?.mid || params?.cookie?.KUGOU_API_MID || '';
+  const uuid = params?.uuid || '-';
+  const dfid = params?.dfid || params?.cookie?.dfid || '-';
+  const type = params?.type || 1;
+
+  // 平台参数（支持 params 覆盖，默认跟随 platform 配置）
+  const appId = String(params?.appid || (isLite ? liteAppid : appid));
+  const appKey = params?.appkey || APPKEY_MAP[isLite ? 'lite' : 'standard'];
+  const clientVer = String(params?.clientver || (isLite ? liteClientver : clientver));
+  const publicKey = params?.publicKey || (isLite ? publicLiteRasKey : publicRasKey);
+
+  const clienttime = Math.floor(Date.now() / 1000);
+  // 请求校验 key：MD5(appid + appkey + clientver + clienttime)
+  const key = crypto
+    .createHash('md5')
+    .update(appId + appKey + clientVer + clienttime)
+    .digest('hex');
+
+  const dataMap = { mid, type, uuid, userid };
+
+  // 上报模式（有缓存）：需要 token 与 d_sec/diff_sec
+  const isReport = params?.d_sec != null && params?.diff_sec != null;
+  let p;
+  if (isReport) {
+    const d_sec = Number(params.d_sec);
+    const diff_sec = Number(params.diff_sec);
+    const y_type = params?.y_type || 0;
+    const m_type = params?.m_type || 0;
+    const md5 = crypto
+      .createHash('md5')
+      .update(String(d_sec) + String(diff_sec) + String(y_type) + String(m_type))
+      .digest('hex');
+    // p 明文：{"token":...,"md5":...}，RSA 加密后 hex 大写
+    p = cryptoRSAEncrypt({ token, md5 }, publicKey).toUpperCase();
+    Object.assign(dataMap, { d_sec, diff_sec, y_type, m_type });
+  } else {
+    // 查询模式（无缓存）：p 明文 {"clienttime":...,"userid":...}
+    const innerJson = JSON.stringify({ clienttime, userid });
+    p = cryptoRSAEncrypt(innerJson, publicKey).toUpperCase();
+  }
+  dataMap.p = p;
+
+  // 公共参数（body 内）
+  Object.assign(dataMap, { appid: appId, clientver: clientVer, clienttime, key });
+
+  return useAxios({
+    baseURL: 'http://userinfo.user.kugou.com',
+    url: '/v2/get_grade_info',
+    method: 'POST',
+    data: dataMap,
+    params: { dfid }, // 仅 dfid 在 URL query
+    clearDefaultParams: true,
+    notSignature: true, // 该接口不生成 signature，key 字段即为请求校验
+    headers: {
+      'Content-Type': 'text/plain; charset=ISO-8859-1',
+      'User-Agent': `Android15-1070-${clientVer}-201-0-get_user_grade_info-wifi`,
+      // 每次请求生成随机的 KG-THash（模拟客户端行为，固定 7 位 hex）
+      'KG-THash': Math.floor(Math.random() * 0xfffffff)
+        .toString(16)
+        .padStart(7, '0'),
+      'KG-Rec': '1',
+      'KG-RC': '1',
+    },
+    cookie: params?.cookie || {},
+  });
+};


### PR DESCRIPTION
### 背景

听歌等级/听歌时长是用户账号体系的重要组成部分，用户查看自己的听歌统计、
等级进度是高频需求。当前项目缺少相关接口，无法查询听歌等级信息，
也无法将用户的听歌时长同步到账号。

本次新增接口，补齐该能力：
- 查询当前账号的听歌等级、累计时长与积分进度
- 上报本地累计听歌时长，同步账号等级成长

### 改动内容

**新增 `module/user_grade_info.js`（路由：`/user/grade/info`）**

支持两种调用方式：
- **查询模式**（默认）：返回账号当前累计听歌时长 `d_sec`、等级 `p_grade`、积分及下一级进度
- **上报模式**：传入 `d_sec`（本地累计秒数）+ `diff_sec`（本次新增秒数），同步听歌时长

核心设计：
- **平台参数自动适配**：appid/appkey/clientver 及 UA 随 `platform` 配置动态切换，调用方无需传参
- 上报校验参数与加密载荷内部自动生成，签名完整性保障

**更新 `docs/README.md`**

- 接口目录新增第 138 条，正文补充完整参数说明与返回示例

### 平台限制

> 本接口为概念版（lite）客户端协议。`platform=lite` 下查询、上报均实测可用；
> 标准版账号（不配置 `platform`）可查询，但**上报不会被记账**（服务端静默忽略）。
> README 与代码注释中均已明确说明。

### 使用示例

```bash
# 查询等级信息（lite 平台）
GET /user/grade/info?cookie=token%3Dxxx%3Buserid%3D123

# 上报听歌时长（lite 平台，d_sec=本地累计秒数，diff_sec=本次新增秒数）
GET /user/grade/info?cookie=token%3Dxxx%3Buserid%3D123&d_sec=100190&diff_sec=190