### PR TITLE
Feat/listen time report

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2580,8 +2580,11 @@ const res = await fetch('/audio/match', {
 - **查询**（默认）：返回服务器当前累计听歌时长、等级与积分
 - **上报**：传入 `d_sec`（本地累计听歌秒数）与 `diff_sec`（本次新增秒数），同步本地累计时长
 
-> **平台限制**：本接口为概念版（lite）客户端协议，仅 `platform=lite` 下上报有效；
-> 标准版账号（不配置 `platform`）可查询，但上报不会记账（服务端静默忽略）。
+**双协议支持**：
+
+- `platform=lite`（概念版）走 **v2 协议**（`userinfo.user.kugou.com/v2/get_grade_info`），上报按 `diff_sec` 累加记账
+- 标准版（不配置 `platform`）走 **v4 协议**（`userinfoservice.kugou.com/v4/get_grade_info`，pk/params 加密结构），**可查询**；但标准版听歌时长由服务端真实播放统计维护，**上报增量不会记账**
+- 可用 `protocol=v2|v4` 参数强制指定协议
 
 **必选参数（登录态）：**
 
@@ -2591,7 +2594,7 @@ const res = await fetch('/audio/match', {
 
 `uuid`：设备 UUID，默认为 `-`
 
-`type`：类型，默认为 `1`
+`type`：类型，默认为 `1`（仅 v2 生效；v4 固定为 `0`）
 
 **上报参数：**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -164,6 +164,7 @@
 135. [`获取已购单曲`](#获取已购单曲)
 136. [`获取已购专辑`](#获取已购专辑)
 137. [`上传音乐到云盘`](#上传音乐到云盘)
+138. [`获取听歌等级信息`](#获取听歌等级信息)
 
 ### 安装
 
@@ -2571,6 +2572,63 @@ const res = await fetch('/audio/match', {
 **接口地址：** `/user/purchased/albums`
 
 **调用例子：** `/user/purchased/albums`
+
+### 获取听歌等级信息
+
+说明：获取并上报用户听歌等级信息（听歌时长），登录后调用。支持两种调用方式：
+
+- **查询**（默认）：返回服务器当前累计听歌时长、等级与积分
+- **上报**：传入 `d_sec`（本地累计听歌秒数）与 `diff_sec`（本次新增秒数），同步本地累计时长
+
+> **平台限制**：本接口为概念版（lite）客户端协议，仅 `platform=lite` 下上报有效；
+> 标准版账号（不配置 `platform`）可查询，但上报不会记账（服务端静默忽略）。
+
+**必选参数（登录态）：**
+
+`cookie`：登录凭证，需包含 `token`、`userid`，建议同时包含 `mid`、`dfid`
+
+**可选参数：**
+
+`uuid`：设备 UUID，默认为 `-`
+
+`type`：类型，默认为 `1`
+
+**上报参数：**
+
+`d_sec`：本地累计听歌秒数（须大于等于服务器当前值）
+
+`diff_sec`：本次新增秒数，请按正常听歌节奏调用
+
+`y_type`：年份类型，默认为 `0`
+
+`m_type`：音乐类型，默认为 `0`
+
+**接口地址：** `/user/grade/info`
+
+**调用例子：**
+
+查询：`/user/grade/info?cookie=token%3Dxxx%3Buserid%3D123`
+
+上报：`/user/grade/info?cookie=token%3Dxxx%3Buserid%3D123&d_sec=123456&diff_sec=600&uuid=xxx`
+
+**返回示例：**
+
+```json
+{
+  "status": 1,
+  "error_code": 0,
+  "data": {
+    "d_sec": 125755,
+    "duration": 2095,
+    "p_grade": 3,
+    "p_current_point": 3809,
+    "p_grade_point": 3000,
+    "p_next_grade": 4,
+    "p_next_grade_point": 6000,
+    "servertime": "2026-08-05 23:10:40"
+  }
+}
+```
 
 ## License
 

--- a/module/user_grade_info.js
+++ b/module/user_grade_info.js
@@ -1,28 +1,119 @@
 // 酷狗听歌等级信息查询与听歌时长上报
 //
-// 两种模式（与官方客户端行为一致）：
+// 两种模式：
 //  1. 查询模式（默认）：返回服务器当前累计听歌时长（d_sec）、等级（p_grade）、积分等
 //  2. 上报模式：传入 d_sec + diff_sec，同步本地累计听歌时长
 //     d_sec    本地累计听歌秒数（须 >= 服务器当前值）
 //     diff_sec 上次同步后的新增秒数
 //     md5      = MD5(d_sec + diff_sec + y_type + m_type)
 //
-// 说明：本协议为概念版（lite）客户端用户等级体系，标准版账号走该协议上报不会被记账；
-// 请在 lite 平台（platform=lite）下使用。服务器按真实时间记账（增量受距上次上报时间约束），
-// 请按正常听歌节奏调用。
+// 双协议支持：
+//  - v2（lite 专属）: userinfo.user.kugou.com/v2/get_grade_info，body 平铺参数 + key 校验
+//  - v4（标准版）   : userinfoservice.kugou.com/v4/get_grade_info，pk(RSA)+params(AES) 加密结构
+// 默认跟随 platform 选择；可用 params.protocol 强制指定（'v2' | 'v4'）。
+//
+// 说明：v2 协议为概念版（lite）客户端用户等级体系，lite 平台（platform=lite）下上报有效
+// （服务器按 diff_sec 累加记账，增量受距上次上报时间约束，请按正常听歌节奏调用）。
+// v4 为标准版客户端协议：pk/params 加密结构 + query signature，标准版账号可查询；
+// 标准版听歌时长由服务端真实播放统计（延迟）维护，get_grade_info 仅作查询/对账，
+// 标准版上报增量不会被记账。
 
 const crypto = require('crypto');
-const { cryptoRSAEncrypt, publicLiteRasKey, publicRasKey } = require('../util');
+const {
+  cryptoAesEncrypt,
+  cryptoMd5,
+  cryptoRSAEncrypt,
+  publicLiteRasKey,
+  publicRasKey,
+} = require('../util');
 const { appid, clientver, liteAppid, liteClientver } = require('../util/config.json');
 
-// 平台签名盐值与 RSA 公钥（与 util/helper.js、util/crypto.js 双平台配置保持一致）
+// 平台签名盐值（与 util/helper.js、util/crypto.js 双平台配置保持一致）
 const APPKEY_MAP = {
   lite: 'LnT6xpN3khm36zse0QzvmgTZ3waWdRSA',
   standard: 'OIlwieks28dk2k092lksi2UIkp',
 };
 
-module.exports = (params, useAxios) => {
-  const isLite = process.env.platform === 'lite';
+// v4 通用请求头（KG-DEVID / KG-CLIENTTIMEMS）
+const v4Headers = (clientVer, mid, ms) => ({
+  'Content-Type': 'application/json; charset=UTF-8',
+  'User-Agent': `Android15-1070-${clientVer}-201-0-get_user_grade_info-wifi`,
+  'KG-DEVID': mid,
+  'KG-CLIENTTIMEMS': String(ms),
+  // 注：request.js 会注入默认 kg-thash/kg-rc/kg-rec/kg-rf，
+  // 实测差异不影响查询与记账结果，这里不强行覆盖
+});
+
+// 构建 v4 上报/查询请求
+const buildV4 = (params, useAxios, cfg) => {
+  const token = params?.token || params?.cookie?.token || '';
+  const userid = String(params?.userid || params?.cookie?.userid || 0);
+  const mid = params?.mid || params?.cookie?.mid || params?.cookie?.KUGOU_API_MID || '';
+  const dfid = params?.dfid || params?.cookie?.dfid || '-';
+  const uuid = params?.uuid || '-';
+  const ms = Date.now();
+  const clienttime = Math.floor(ms / 1000);
+
+  const { appId, appKey, clientVer, publicKey } = cfg;
+
+  // y_type/m_type（默认 0）
+  const y_type = params?.y_type || 0;
+  const m_type = params?.m_type || 0;
+  const d_sec = params?.d_sec != null ? Number(params.d_sec) : 0;
+  const diff_sec = params?.diff_sec != null ? Number(params.diff_sec) : 0;
+
+  // md5 = MD5(d_sec + diff_sec + y_type + m_type)
+  const md5 = cryptoMd5(String(d_sec) + String(diff_sec) + String(y_type) + String(m_type));
+
+  // AES 种子 key：16 位纯 hex（AES-128 生成 key 后 hex 取前 16 位）
+  const aesSeed = crypto.randomBytes(8).toString('hex');
+  const seedMd5 = cryptoMd5(aesSeed);
+  // params 加密：AES-256-CBC，key=MD5(seed)[0:32]，iv=MD5(seed)[16:32]
+  const paramsEnc = cryptoAesEncrypt(
+    { userid, token, md5 },
+    { key: seedMd5.substring(0, 32), iv: seedMd5.substring(16, 32) }
+  );
+  // pk：RSA/ECB/NOPADDING 加密 {clienttime_ms, key}（hex 小写）
+  const pk = cryptoRSAEncrypt({ clienttime_ms: ms, key: aesSeed }, publicKey);
+
+  const body = {
+    plat: 1,
+    userid,
+    clienttime_ms: ms,
+    type: 0,
+    d_sec,
+    diff_sec,
+    y_type,
+    m_type,
+    pk,
+    params: paramsEnc,
+    medal: 0,
+  };
+  const bodyStr = JSON.stringify(body);
+
+  // query 参数 + signature：MD5(appkey + 排序query + body + appkey)
+  const signParams = { clienttime, mid, dfid, uuid, appid: appId, clientver: clientVer };
+  const signStr = Object.keys(signParams)
+    .sort()
+    .map((k) => `${k}=${signParams[k]}`)
+    .join('');
+  const signature = cryptoMd5(`${appKey}${signStr}${bodyStr}${appKey}`);
+
+  return useAxios({
+    baseURL: 'https://userinfoservice.kugou.com',
+    url: '/v4/get_grade_info',
+    method: 'POST',
+    data: bodyStr,
+    params: Object.assign({}, signParams, { signature }),
+    clearDefaultParams: true,
+    notSignature: true, // signature 已在请求中，跳过自动签名
+    headers: v4Headers(clientVer, mid, ms),
+    cookie: params?.cookie || {},
+  });
+};
+
+// 构建 v2 上报/查询请求（lite 客户端，原有实现）
+const buildV2 = (params, useAxios, cfg) => {
   const token = params?.token || params?.cookie?.token || '';
   const userid = Number(params?.userid || params?.cookie?.userid || 0);
   const mid = params?.mid || params?.cookie?.mid || params?.cookie?.KUGOU_API_MID || '';
@@ -30,13 +121,9 @@ module.exports = (params, useAxios) => {
   const dfid = params?.dfid || params?.cookie?.dfid || '-';
   const type = params?.type || 1;
 
-  // 平台参数（支持 params 覆盖，默认跟随 platform 配置）
-  const appId = String(params?.appid || (isLite ? liteAppid : appid));
-  const appKey = params?.appkey || APPKEY_MAP[isLite ? 'lite' : 'standard'];
-  const clientVer = String(params?.clientver || (isLite ? liteClientver : clientver));
-  const publicKey = params?.publicKey || (isLite ? publicLiteRasKey : publicRasKey);
-
+  const { appId, appKey, clientVer, publicKey } = cfg;
   const clienttime = Math.floor(Date.now() / 1000);
+
   // 请求校验 key：MD5(appid + appkey + clientver + clienttime)
   const key = crypto
     .createHash('md5')
@@ -90,4 +177,20 @@ module.exports = (params, useAxios) => {
     },
     cookie: params?.cookie || {},
   });
+};
+
+module.exports = (params, useAxios) => {
+  const isLite = process.env.platform === 'lite';
+  const protocol = params?.protocol || (isLite ? 'v2' : 'v4');
+
+  // 平台参数（支持 params 覆盖；v4 为标准版专属，固定标准平台配置）
+  const useV4 = protocol === 'v4';
+  const cfg = {
+    appId: String(params?.appid || (useV4 ? appid : isLite ? liteAppid : appid)),
+    appKey: params?.appkey || APPKEY_MAP[useV4 ? 'standard' : isLite ? 'lite' : 'standard'],
+    clientVer: String(params?.clientver || (useV4 ? clientver : isLite ? liteClientver : clientver)),
+    publicKey: params?.publicKey || (useV4 ? publicRasKey : isLite ? publicLiteRasKey : publicRasKey),
+  };
+
+  return useV4 ? buildV4(params, useAxios, cfg) : buildV2(params, useAxios, cfg);
 };

--- a/module/user_grade_info.js
+++ b/module/user_grade_info.js
@@ -1,0 +1,93 @@
+// 酷狗听歌等级信息查询与听歌时长上报
+//
+// 两种模式（与官方客户端行为一致）：
+//  1. 查询模式（默认）：返回服务器当前累计听歌时长（d_sec）、等级（p_grade）、积分等
+//  2. 上报模式：传入 d_sec + diff_sec，同步本地累计听歌时长
+//     d_sec    本地累计听歌秒数（须 >= 服务器当前值）
+//     diff_sec 上次同步后的新增秒数
+//     md5      = MD5(d_sec + diff_sec + y_type + m_type)
+//
+// 说明：本协议为概念版（lite）客户端用户等级体系，标准版账号走该协议上报不会被记账；
+// 请在 lite 平台（platform=lite）下使用。服务器按真实时间记账（增量受距上次上报时间约束），
+// 请按正常听歌节奏调用。
+
+const crypto = require('crypto');
+const { cryptoRSAEncrypt, publicLiteRasKey, publicRasKey } = require('../util');
+const { appid, clientver, liteAppid, liteClientver } = require('../util/config.json');
+
+// 平台签名盐值与 RSA 公钥（与 util/helper.js、util/crypto.js 双平台配置保持一致）
+const APPKEY_MAP = {
+  lite: 'LnT6xpN3khm36zse0QzvmgTZ3waWdRSA',
+  standard: 'OIlwieks28dk2k092lksi2UIkp',
+};
+
+module.exports = (params, useAxios) => {
+  const isLite = process.env.platform === 'lite';
+  const token = params?.token || params?.cookie?.token || '';
+  const userid = Number(params?.userid || params?.cookie?.userid || 0);
+  const mid = params?.mid || params?.cookie?.mid || params?.cookie?.KUGOU_API_MID || '';
+  const uuid = params?.uuid || '-';
+  const dfid = params?.dfid || params?.cookie?.dfid || '-';
+  const type = params?.type || 1;
+
+  // 平台参数（支持 params 覆盖，默认跟随 platform 配置）
+  const appId = String(params?.appid || (isLite ? liteAppid : appid));
+  const appKey = params?.appkey || APPKEY_MAP[isLite ? 'lite' : 'standard'];
+  const clientVer = String(params?.clientver || (isLite ? liteClientver : clientver));
+  const publicKey = params?.publicKey || (isLite ? publicLiteRasKey : publicRasKey);
+
+  const clienttime = Math.floor(Date.now() / 1000);
+  // 请求校验 key：MD5(appid + appkey + clientver + clienttime)
+  const key = crypto
+    .createHash('md5')
+    .update(appId + appKey + clientVer + clienttime)
+    .digest('hex');
+
+  const dataMap = { mid, type, uuid, userid };
+
+  // 上报模式（有缓存）：需要 token 与 d_sec/diff_sec
+  const isReport = params?.d_sec != null && params?.diff_sec != null;
+  let p;
+  if (isReport) {
+    const d_sec = Number(params.d_sec);
+    const diff_sec = Number(params.diff_sec);
+    const y_type = params?.y_type || 0;
+    const m_type = params?.m_type || 0;
+    const md5 = crypto
+      .createHash('md5')
+      .update(String(d_sec) + String(diff_sec) + String(y_type) + String(m_type))
+      .digest('hex');
+    // p 明文：{"token":...,"md5":...}，RSA 加密后 hex 大写
+    p = cryptoRSAEncrypt({ token, md5 }, publicKey).toUpperCase();
+    Object.assign(dataMap, { d_sec, diff_sec, y_type, m_type });
+  } else {
+    // 查询模式（无缓存）：p 明文 {"clienttime":...,"userid":...}
+    const innerJson = JSON.stringify({ clienttime, userid });
+    p = cryptoRSAEncrypt(innerJson, publicKey).toUpperCase();
+  }
+  dataMap.p = p;
+
+  // 公共参数（body 内）
+  Object.assign(dataMap, { appid: appId, clientver: clientVer, clienttime, key });
+
+  return useAxios({
+    baseURL: 'http://userinfo.user.kugou.com',
+    url: '/v2/get_grade_info',
+    method: 'POST',
+    data: dataMap,
+    params: { dfid }, // 仅 dfid 在 URL query
+    clearDefaultParams: true,
+    notSignature: true, // 该接口不生成 signature，key 字段即为请求校验
+    headers: {
+      'Content-Type': 'text/plain; charset=ISO-8859-1',
+      'User-Agent': `Android15-1070-${clientVer}-201-0-get_user_grade_info-wifi`,
+      // 每次请求生成随机的 KG-THash（模拟客户端行为，固定 7 位 hex）
+      'KG-THash': Math.floor(Math.random() * 0xfffffff)
+        .toString(16)
+        .padStart(7, '0'),
+      'KG-Rec': '1',
+      'KG-RC': '1',
+    },
+    cookie: params?.cookie || {},
+  });
+};


### PR DESCRIPTION
### 概述

新增 `/user/grade/info` 接口，用于获取并上报账号的听歌等级信息（听歌时长、等级、积分），需登录后调用。

接口支持两种客户端协议，默认跟随 `platform` 配置自动选择，也可用 `protocol` 参数强制指定：

- **v2 协议**（概念版 lite，`platform=lite`）：`userinfo.user.kugou.com/v2/get_grade_info`
  - body 平铺参数 + RSA 加密的请求校验 `p` 字段 + MD5 请求 `key`
  - lite 平台下**上报有效**：服务器按 `diff_sec` 累加记账
- **v4 协议**（标准版）：`userinfoservice.kugou.com/v4/get_grade_info`
  - 加密结构：`pk`（RSA/ECB/NOPADDING 加密 `{clienttime_ms, key}`）+ `params`（AES-256-CBC，
    key/iv 取自 MD5(seed)）承载 `{userid, token, md5}`
  - 请求校验：query 签名 `MD5(appkey + 排序参数 + body + appkey)`，携带 `KG-DEVID` / `KG-CLIENTTIMEMS` 请求头
  - 标准版账号可**查询**；听歌时长由服务端真实播放统计维护，上报增量不会被记账

### 接口用法

- **查询**（默认）：返回服务器当前累计听歌时长 `d_sec`、等级 `p_grade`、积分等
- **上报**：传入 `d_sec`（本地累计听歌秒数，须 >= 服务器当前值）+ `diff_sec`（本次新增秒数），同步本地累计时长
