### PR TITLE
feat:添加组队相关接口

### DIFF
--- a/module/team_join.js
+++ b/module/team_join.js
@@ -1,0 +1,73 @@
+//加入队伍
+const crypto = require('crypto');
+const { cryptoMd5,appid,clientver,srcappid,publicLiteRasKey } = require('../util');
+
+function rsaNoPadEncrypt(data, publicKeyPem) {
+    const key = crypto.createPublicKey(publicKeyPem);
+    const encrypted = crypto.publicEncrypt(
+        {
+            key: key,
+            padding: crypto.constants.RSA_NO_PADDING,
+        },
+        data
+    );
+    return encrypted.toString('hex');
+}
+
+//带请求体签名
+function signatureWebParamsWithBody(params, bodyStr) {
+    const SALT = 'NVPh5oo715z5DIWAeQlhMDsWXXQV4hwt';
+    const paramsString = Object.keys(params)
+        .sort()
+        .map(k => `${k}=${params[k]}`)
+        .join('');
+    const input = SALT + paramsString + bodyStr + SALT;
+    return cryptoMd5(input);
+}
+
+module.exports = (params, useAxios) => {
+
+    const rawToken = params?.token || params?.cookie?.token || '';
+    const userid = Number(params?.userid || params?.cookie?.userid || '0');
+    const mid = params?.cookie?.KUGOU_API_MID || params?.mid || '';
+    const dfid = params?.dfid || params?.cookie?.dfid || '-';
+    const uuid = params?.uuid || params?.cookie?.uuid || '-';
+
+    let token = rawToken;
+    const prefix = 'moc.uoguk.59::';                
+    const input = Buffer.from(prefix + rawToken, 'utf8');
+    const padded = Buffer.alloc(128);
+    input.copy(padded);
+
+    const encrypted = rsaNoPadEncrypt(padded, publicLiteRasKey).toUpperCase();
+    token = 'h5' + encrypted;                       
+
+    const clienttime = Date.now();
+    const paramsMap = {
+        srcappid,
+        clientver,
+        clienttime,
+        mid,
+        uuid,
+        dfid,
+        appid,
+        userid,
+        token,
+    };
+
+    const dataMap = { team_code: params.team_code };
+    //转为字符串参与签名
+    const dataStr = JSON.stringify(dataMap);
+
+    const signature = signatureWebParamsWithBody(paramsMap, dataStr);
+    const finalParams = { ...paramsMap, signature };
+
+    return useAxios({
+        url: '/youth/v1/ut/join_team',
+        method: 'POST',
+        data: dataMap,
+        params: finalParams,
+        cookie: params?.cookie || {},
+        headers: { 'Host': 'gateway.kugou.com' },
+    });
+};

--- a/module/team_my.js
+++ b/module/team_my.js
@@ -1,0 +1,72 @@
+//创建我的队伍
+const crypto = require('crypto');
+const { cryptoMd5,appid,clientver,srcappid,publicLiteRasKey } = require('../util');
+
+function rsaNoPadEncrypt(data, publicKeyPem) {
+    const key = crypto.createPublicKey(publicKeyPem);
+    const encrypted = crypto.publicEncrypt(
+        {
+            key: key,
+            padding: crypto.constants.RSA_NO_PADDING,
+        },
+        data
+    );
+    return encrypted.toString('hex');
+}
+
+//携带请求体进行签名
+function signatureWebParamsWithBody(params, bodyStr) {
+    const SALT = 'NVPh5oo715z5DIWAeQlhMDsWXXQV4hwt';
+    const paramsString = Object.keys(params)
+        .sort()
+        .map(k => `${k}=${params[k]}`)
+        .join('');
+    const input = SALT + paramsString + bodyStr + SALT;
+    return cryptoMd5(input);
+}
+
+module.exports = (params, useAxios) => {
+
+    const rawToken = params?.token || params?.cookie?.token || '';
+    const userid = Number(params?.userid || params?.cookie?.userid || '0');
+    const mid = params?.cookie?.KUGOU_API_MID || params?.mid || '';
+    const dfid = params?.dfid || params?.cookie?.dfid || '-';
+    const uuid = params?.uuid || params?.cookie?.uuid || '-';
+
+    let token = rawToken;
+    const prefix = 'moc.uoguk.59::';                
+    const input = Buffer.from(prefix + rawToken, 'utf8');
+    const padded = Buffer.alloc(128);
+    input.copy(padded);
+
+    const encrypted = rsaNoPadEncrypt(padded, publicLiteRasKey).toUpperCase();
+    token = 'h5' + encrypted;
+    const clienttime = Date.now();
+    const paramsMap = {
+        srcappid,
+        clientver,
+        clienttime,
+        mid,
+        uuid,
+        dfid,
+        appid,
+        userid,
+        token,
+    };
+
+    const dataMap = { period_id: params.period_id };
+    //转为字符串参与签名
+    const dataStr = JSON.stringify(dataMap);
+
+    const signature = signatureWebParamsWithBody(paramsMap, dataStr);
+    const finalParams = { ...paramsMap, signature };
+
+    return useAxios({
+        url: '/youth/v1/ut/create_team',
+        method: 'POST',
+        data: dataMap,
+        params: finalParams,
+        cookie: params?.cookie || {},
+        headers: { 'Host': 'gateway.kugou.com' },
+    });
+};

--- a/module/team_my_info.js
+++ b/module/team_my_info.js
@@ -1,0 +1,58 @@
+//获取我的队伍状态
+const crypto = require('crypto');
+const { signatureWebParams,appid,clientver,srcappid,publicLiteRasKey } = require('../util');
+
+function rsaNoPadEncrypt(data, publicKeyPem) {
+    const key = crypto.createPublicKey(publicKeyPem);
+    const encrypted = crypto.publicEncrypt(
+        {
+            key: key,
+            padding: crypto.constants.RSA_NO_PADDING,
+        },
+        data
+    );
+    return encrypted.toString('hex');
+}
+
+module.exports = (params, useAxios) => {
+
+    const rawToken = params?.token || params?.cookie?.token || '';
+    const userid = Number(params?.userid || params?.cookie?.userid || '0');
+    const mid = params?.cookie?.KUGOU_API_MID || params?.mid || '';
+    const dfid = params?.dfid || params?.cookie?.dfid || '-';
+    const uuid = params?.uuid || params?.cookie?.uuid || '-';
+
+    let token = rawToken;
+    const prefix = 'moc.uoguk.59::';                
+    const input = Buffer.from(prefix + rawToken, 'utf8');
+    const padded = Buffer.alloc(128);
+    input.copy(padded);
+
+    const encrypted = rsaNoPadEncrypt(padded, publicLiteRasKey).toUpperCase();
+    token = 'h5' + encrypted;                       
+
+    const clienttime = Date.now();
+    const dataMap = {
+        srcappid,
+        clientver,
+        clienttime,
+        mid,
+        uuid,
+        dfid,
+        appid,
+        userid,
+        token,
+        period_id: params.period_id
+    };
+
+    const signature = signatureWebParams(dataMap);     
+    const finalParams = { ...dataMap, signature };      
+
+    return useAxios({
+        url: '/youth/v1/ut/get_my_team_info',
+        method: 'GET',
+        params: finalParams,
+        cookie: params?.cookie || {},
+        headers: { 'Host':'gateway.kugou.com'}
+    });
+};

--- a/module/team_my_status.js
+++ b/module/team_my_status.js
@@ -1,0 +1,58 @@
+//获取我的状态（加入队伍、创建队伍等）
+const crypto = require('crypto');
+const { signatureWebParams,appid,clientver,srcappid,publicLiteRasKey } = require('../util');
+
+function rsaNoPadEncrypt(data, publicKeyPem) {
+    const key = crypto.createPublicKey(publicKeyPem);
+    const encrypted = crypto.publicEncrypt(
+        {
+            key: key,
+            padding: crypto.constants.RSA_NO_PADDING,
+        },
+        data
+    );
+    return encrypted.toString('hex');
+}
+
+module.exports = (params, useAxios) => {
+
+    const rawToken = params?.token || params?.cookie?.token || '';
+    const userid = Number(params?.userid || params?.cookie?.userid || '0');
+    const mid = params?.cookie?.KUGOU_API_MID || params?.mid || '';
+    const dfid = params?.dfid || params?.cookie?.dfid || '-';
+    const uuid = params?.uuid || params?.cookie?.uuid || '-';
+
+    let token = rawToken;
+    const prefix = 'moc.uoguk.59::';                
+    const input = Buffer.from(prefix + rawToken, 'utf8');
+    const padded = Buffer.alloc(128);
+    input.copy(padded);
+
+    const encrypted = rsaNoPadEncrypt(padded, publicLiteRasKey).toUpperCase();
+    token = 'h5' + encrypted;                       
+
+    const clienttime = Date.now();
+    const dataMap = {
+        srcappid,
+        clientver,
+        clienttime,
+        mid,
+        uuid,
+        dfid,
+        appid,
+        userid,
+        token,
+        period_id: params.period_id
+    };
+
+    const signature = signatureWebParams(dataMap);     
+    const finalParams = { ...dataMap, signature };      
+
+    return useAxios({
+        url: '/youth/v1/ut/get_user_status',
+        method: 'GET',
+        params: finalParams,
+        cookie: params?.cookie || {},
+        headers: { 'Host':'gateway.kugou.com'}
+    });
+};

--- a/module/team_period_info.js
+++ b/module/team_period_info.js
@@ -1,0 +1,57 @@
+//获取本期活动状态
+const crypto = require('crypto');
+const { signatureWebParams,appid,clientver,srcappid,publicLiteRasKey } = require('../util');
+
+function rsaNoPadEncrypt(data, publicKeyPem) {
+    const key = crypto.createPublicKey(publicKeyPem);
+    const encrypted = crypto.publicEncrypt(
+        {
+            key: key,
+            padding: crypto.constants.RSA_NO_PADDING,
+        },
+        data
+    );
+    return encrypted.toString('hex');
+}
+
+module.exports = (params, useAxios) => {
+
+    const rawToken = params?.token || params?.cookie?.token || '';
+    const userid = Number(params?.userid || params?.cookie?.userid || '0');
+    const mid = params?.cookie?.KUGOU_API_MID || params?.mid || '';
+    const dfid = params?.dfid || params?.cookie?.dfid || '-';
+    const uuid = params?.uuid || params?.cookie?.uuid || '-';
+
+    let token = rawToken;
+    const prefix = 'moc.uoguk.59::';                
+    const input = Buffer.from(prefix + rawToken, 'utf8');
+    const padded = Buffer.alloc(128);
+    input.copy(padded);
+
+    const encrypted = rsaNoPadEncrypt(padded, publicLiteRasKey).toUpperCase();
+    token = 'h5' + encrypted;                       
+
+    const clienttime = Date.now();
+    const dataMap = {
+        srcappid,
+        clientver,
+        clienttime,
+        mid,
+        uuid,
+        dfid,
+        appid,
+        userid,
+        token
+    };
+
+    const signature = signatureWebParams(dataMap);     
+    const finalParams = { ...dataMap, signature };    
+
+    return useAxios({
+        url: '/youth/v1/ut/get_period_info',
+        method: 'GET',
+        params: finalParams,
+        cookie: params?.cookie || {},
+        headers: { 'Host':'gateway.kugou.com'}
+    });
+};


### PR DESCRIPTION
## 摘要

### 说明
添加概念版app中组队领取vip的相关接口，即下面板块
<img width="846" height="271" alt="image" src="https://github.com/user-attachments/assets/40b47113-cf65-4939-8de2-85ba0682620b" />

### 文档（未写入PR）

#### 获取本期活动信息（需要登陆，该接口为测试接口，仅限概念版使用）

说明：登录后调用此接口，可以获取本次组队活动信息

**接口地址**：  `/team/period/info`

**调用例子**：  `/team/period/info`

#### 获取用户组队信息（需要登陆，该接口为测试接口，仅限概念版使用）

说明：登录后调用此接口，可以获取用户组队信息，比如是否加入队伍或自己创建队伍

必选参数：`period_id`：本期活动信息返回的`id`字段

**接口地址**： `/team/my/status`

**调用例子**： `/team/my/status?period_id=280`

#### 获取用户自己的队伍信息（需要登陆，该接口为测试接口，仅限概念版使用）

说明：登录后调用此接口，可以获取用户自己组建的队伍信息

必选参数：`period_id`：本期活动信息返回的`id`字段

**接口地址**：  `/team/my/info`

**调用例子**：  `/team/my/info?period_id=280`

#### 创建用户自己的组队队伍（需要登陆，该接口为测试接口，仅限概念版使用）

说明：登录后调用此接口，可以创建用户自己的组队队伍获取vip

必选参数：`period_id`：本期活动信息返回的`id`字段

**接口地址**： `/team/my`

**调用例子**： `/team/my?period_id=280`

#### 加入组队队伍（需要登陆，该接口为测试接口，仅限概念版使用）

说明：登录后调用此接口，可以加入别人的组队队伍

必选参数：`team_code`：欲加入队伍的组队码

**接口地址**：  `/team/join`

**调用例子**： `/team/join?team_code=j9n0fd`

### 效果验证

A
<img width="1005" height="501" alt="image" src="https://github.com/user-attachments/assets/60ef1a6e-01f2-4a3c-9de5-0dbdd035858d" />
B
<img width="1004" height="505" alt="image" src="https://github.com/user-attachments/assets/4e2ef05d-4c71-40c8-9d23-782f2da3e278" />
C
<img width="1000" height="503" alt="image" src="https://github.com/user-attachments/assets/3b49b9de-e401-47b5-b08a-4fe0aa552df2" />
D
<img width="1006" height="505" alt="image" src="https://github.com/user-attachments/assets/e81e0632-f8e4-4a7e-acca-e85a52d81590" />
E
<img width="1013" height="506" alt="image" src="https://github.com/user-attachments/assets/6f586814-9237-4c5b-980d-be4095fa3dfb" />

### 注意事项
接口访问可能被验证码拦截，做好验证准备。

⚠警告：不要频繁访问以上接口，可能导致账号风控，奖励回收或接口失效。每期活动只允许调用一次创建队伍接口，不得频繁使用。