### PR TITLE
feat: add qq login support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -393,9 +393,9 @@ $ set HOST=127.0.0.1 && npm run dev
 
 **调用例子：** `/login?username=xxx&password=yyy`
 
-#### 3. 开放接口登录(目前仅支持微信登录)
+#### 3. 微信开放接口登录
 
-说明: 该接口为第三方平台登录，目前仅支持微信登录
+说明: 该接口仅用于微信登录，接收微信扫码成功后生成的 `code`。微信与 QQ 的授权参数不通用，QQ 登录请使用 [`/login/qq`](#_4-qq-授权登录)。
 
 **必选参数：**
 
@@ -405,7 +405,23 @@ $ set HOST=127.0.0.1 && npm run dev
 
 **调用例子：** `/login/openplat?code=xxx`
 
-#### 4. 二维码登录
+#### 4. QQ 授权登录
+
+说明: 该接口仅用于 QQ 登录，接收 QQ 开放平台授权返回的 `openid` 与 `access_token`，并通过酷狗 `login_by_openplat` 换取酷狗登录态。QQ 与微信的授权参数不通用，不能把微信 `code` 传给该接口，也不能把 QQ 参数传给 `/login/openplat`。
+
+**必选参数：**
+
+`openid`: QQ 授权返回的 openid
+
+`access_token`: QQ 授权返回的 access_token
+
+**接口地址：** `/login/qq`
+
+**调用例子：** `/login/qq?openid=xxx&access_token=yyy`
+
+> QQ 登录的 `openid` 与 `access_token` 需通过 QQ 开放平台授权获取（`openmobile.qq.com/oauth2.0/m_authorize`，client_id 按平台自动选择：概念版 `101706348`、标准版 `205141`）。`third_appid` 会根据 `platform` 环境变量自动选择。
+
+#### 5. 二维码登录
 
 说明: 二维码登录涉及到 3 个接口,调用务必带上时间戳,防止缓存
 
@@ -444,9 +460,9 @@ $ set HOST=127.0.0.1 && npm run dev
 
 **调用例子：** `/login/qr/check?key=xxx`
 
-#### 5. 微信登录
+#### 6. 微信扫码登录
 
-说明：微信登录涉及到 2 个接口,调用务必带上时间戳,防止缓存
+说明：微信扫码登录涉及到 2 个接口,调用务必带上时间戳,防止缓存。该流程使用微信的 `uuid` / `wx_code`，不适用于 QQ 扫码登录。
 
 ##### 1. 二维码生成接口
 
@@ -456,10 +472,10 @@ $ set HOST=127.0.0.1 && npm run dev
 
 **调用例子：** `/login/wx/create`
 
-##### 2.二维码检测扫码状态接口
+##### 2. 微信二维码检测扫码状态接口
 
-说明：轮询此接口可获取二维码扫码状态, 408 为等待扫描，404 为已经扫描，403 为拒绝登录，405 为登录成功，402 为已过期(405 状态下登陆完成口会返回 wx_code,
-用于开放登陆 [`/login/openplat`](#_3-开放接口登录目前仅支持微信登录)), 注：该接口有一定延时，不可访问是可以直接到
+说明：轮询微信接口可获取二维码扫码状态, 408 为等待扫描，404 为已经扫描，403 为拒绝登录，405 为登录成功，402 为已过期(405 状态下登陆完成口会返回 wx_code,
+用于开放登陆 [`/login/openplat`](#_3-微信开放接口登录)), 注：该接口有一定延时，不可访问是可以直接到
 https://long.open.weixin.qq.com/connect/l/qrconnect?f=json&uuid=xxx 该接口直接请求
 
 **必选参数：**
@@ -473,6 +489,71 @@ https://long.open.weixin.qq.com/connect/l/qrconnect?f=json&uuid=xxx 该接口直
 **接口地址：** `/login/wx/check`
 
 **调用例子：** `/login/wx/check?timestamp=1691256061923&uuid=xxxxxxxxx`
+
+#### 7. QQ 扫码登录
+
+说明：QQ 扫码登录涉及 2 个接口，同样是“生成二维码 → 轮询扫码状态 → 换取酷狗登录态”的流程，但 QQ 使用 `qrsig` / `ptqrtoken` / `openid` / `access_token`，与微信的 `uuid` / `code` 不通用，也不会请求 `long.open.weixin.qq.com`。
+
+##### 1. 二维码生成接口
+
+说明：调用此接口可生成 QQ 扫码登录二维码，返回二维码图片 base64、qrsig、ptqrtoken 等会话信息
+
+**接口地址：** `/login/qq/qr/create`
+
+**调用例子：** `/login/qq/qr/create`
+
+返回参数说明：
+
+- `qrcode`: 二维码图片 base64（可直接用 `<img src="data:image/png;base64,xxx">` 展示）
+- `qrsig`: 二维码会话标识
+- `ptqrtoken`: qrsig 的 hash33 值
+- `pt_login_sig`: QQ 登录签名
+- `pt_openlogin_data`: xlogin 完整参数（含 h5sig），轮询扫码状态时需要
+- `xlogin_url`: xlogin 接口完整链接（作为轮询请求的 Referer）
+- `cookie`: 会话 Cookie
+
+##### 2. QQ 二维码检测扫码状态接口
+
+说明：轮询 QQ `ptqrlogin` 接口可获取二维码扫码状态，扫码成功后会自动完成酷狗账号登录并返回 token
+
+**必选参数：**
+
+`qrsig`: 由第一个接口生成
+
+`ptqrtoken`: 由第一个接口生成
+
+`pt_login_sig`: 由第一个接口生成
+
+`pt_openlogin_data`: 由第一个接口生成，需原样传递，否则扫码成功后可能无法直接获取 `openid` / `access_token`
+
+`xlogin_url`: 由第一个接口生成（作为轮询请求的 Referer）
+
+`cookie`: 由第一个接口生成，需原样传递（包含 QQ 扫码会话 Cookie，如 `qrsig`）
+
+**可选参数：**
+
+`timestamp`: 建议放在 URL query 中传递（包括 POST 请求），否则由于 2 分钟 URL 缓存会导致延迟
+
+**接口地址：** `/login/qq/qr/check`
+
+**调用例子：** 将 `/login/qq/qr/create` 返回的会话字段通过 GET query 原样传入；`pt_openlogin_data`、`xlogin_url`、`cookie` 需 URL 编码：
+
+```text
+/login/qq/qr/check?timestamp=1691256061923&qrsig=xxx&ptqrtoken=xxx&pt_login_sig=xxx&pt_openlogin_data=xxx&xlogin_url=xxx&cookie=pt_login_sig%3Dxxx%3B%20qrsig%3Dxxx
+```
+
+返回状态说明：
+
+- `wait`: 等待扫码
+- `expired`: 二维码已失效，需重新调用 create 生成
+- `status: 1`: 登录成功，返回酷狗 token（通过 `/login/qq` 相同流程的 login_by_openplat 换取）
+
+> QQ 扫码登录的 `client_id` 按平台自动选择：概念版 `101706348`、标准版 `205141`。
+>
+> 流程说明（与酷狗 App 内 QQ 扫码登录一致）：
+> 1. `m_authorize`（style=qr）→ `xlogin`（获取 pt_login_sig cookie 及 h5sig）→ `ptqrshow`（二维码）
+> 2. 轮询 `ptqrlogin`，需携带 `pt_openlogin_data`（xlogin 完整参数）、`login_sig`、`qrsig` cookie
+> 3. 扫码成功后直接返回 proxy.htm URL（含 openid + access_token），调用 `login_by_openplat` 换取酷狗 token
 
 ### 刷新登录
 

--- a/interface.d.ts
+++ b/interface.d.ts
@@ -220,10 +220,18 @@ export interface LoginParams extends CommonParams {
   password: string;
 }
 
-/** 开放接口登录参数（目前仅支持微信） */
+/** 微信开放接口登录参数 */
 export interface LoginOpenplatParams extends CommonParams {
   /** 微信扫码成功后生成的 code（必选） */
   code: string;
+}
+
+/** QQ 授权登录参数 */
+export interface LoginQqParams extends CommonParams {
+  /** QQ 授权返回的 openid（必选） */
+  openid: string;
+  /** QQ 授权返回的 access_token（必选） */
+  access_token: string;
 }
 
 /** 二维码 key 生成参数 */
@@ -250,6 +258,27 @@ export interface LoginWxCreateParams extends CommonParams {}
 export interface LoginWxCheckParams extends CommonParams {
   /** 由 `/login/wx/create` 生成的 uuid（必选） */
   uuid: string;
+  /** 建议传递，避免缓存导致延迟 */
+  timestamp?: number | string;
+}
+
+/** QQ 二维码生成参数 */
+export interface LoginQqQrCreateParams extends CommonParams {}
+
+/** QQ 二维码扫码状态检测参数 */
+export interface LoginQqQrCheckParams extends CommonParams {
+  /** 由 `/login/qq/qr/create` 返回的 QQ 扫码会话 Cookie（必选） */
+  cookie: string | CookieMap;
+  /** 由 `/login/qq/qr/create` 生成的 qrsig（必选） */
+  qrsig: string;
+  /** qrsig 的 hash33 值，由 `/login/qq/qr/create` 返回（必选） */
+  ptqrtoken: string | number;
+  /** QQ 登录签名，由 `/login/qq/qr/create` 返回（必选） */
+  pt_login_sig: string;
+  /** xlogin 完整参数（含 h5sig），由 `/login/qq/qr/create` 返回（必选） */
+  pt_openlogin_data: string;
+  /** xlogin 接口完整链接，用作轮询 Referer（必选） */
+  xlogin_url: string;
   /** 建议传递，避免缓存导致延迟 */
   timestamp?: number | string;
 }
@@ -1638,10 +1667,16 @@ export function login_cellphone(params: LoginCellphoneParams): Promise<ApiRespon
 export function login(params: LoginParams): Promise<ApiResponse>;
 
 /**
- * 开放接口登录（目前仅支持微信）
+ * 微信开放接口登录
  * @route /login/openplat
  */
 export function login_openplat(params: LoginOpenplatParams): Promise<ApiResponse>;
+
+/**
+ * QQ 授权登录
+ * @route /login/qq
+ */
+export function login_qq(params: LoginQqParams): Promise<ApiResponse>;
 
 /**
  * 二维码登录 - 生成 key
@@ -1681,6 +1716,18 @@ export function login_wx_create(params?: LoginWxCreateParams): Promise<ApiRespon
  * @route /login/wx/check
  */
 export function login_wx_check(params: LoginWxCheckParams): Promise<ApiResponse>;
+
+/**
+ * QQ 登录 - 生成二维码
+ * @route /login/qq/qr/create
+ */
+export function login_qq_qr_create(params?: LoginQqQrCreateParams): Promise<ApiResponse>;
+
+/**
+ * QQ 登录 - 检测扫码状态，扫码成功后返回酷狗登录态
+ * @route /login/qq/qr/check
+ */
+export function login_qq_qr_check(params: LoginQqQrCheckParams): Promise<ApiResponse>;
 
 /**
  * 刷新登录状态，延长 token 过期时间

--- a/module/login_qq.js
+++ b/module/login_qq.js
@@ -1,0 +1,76 @@
+// QQ 授权登录
+const { cryptoAesDecrypt, cryptoAesEncrypt, cryptoRSAEncrypt, qq_appid, qq_lite_appid, isLite } = require('../util');
+
+let liteT2Key = 'fd14b35e3f81af3817a20ae7adae7020';
+let liteT2Iv = '17a20ae7adae7020';
+let liteT1Key = '5e4ef500e9597fe004bd09a46d8add98';
+let liteT1Iv = '04bd09a46d8add98';
+
+module.exports = (params, useAxios) => {
+  const answer = { status: 500, body: {}, cookie: [] };
+  return new Promise(async (resolve, reject) => {
+    try {
+      const openid = params?.openid || '';
+      const access_token = params?.access_token || '';
+
+      if (!openid || !access_token) {
+        answer.status = 502;
+        answer.body = { status: 0, msg: '缺少 openid 或 access_token' };
+        reject(answer);
+        return;
+      }
+
+      const dateNow = Date.now();
+      const encrypt = cryptoAesEncrypt({ access_token });
+      const pk = cryptoRSAEncrypt({ clienttime_ms: dateNow, key: encrypt.key }).toUpperCase();
+      const t2 = cryptoAesEncrypt(
+        `${params.cookie?.KUGOU_API_GUID}|0f607264fc6318a92b9e13c65db7cd3c|${params.cookie?.KUGOU_API_MAC}|${params.cookie?.KUGOU_API_DEV}|${dateNow}`,
+        { key: liteT2Key, iv: liteT2Iv }
+      );
+      const t1 = cryptoAesEncrypt(`|${dateNow}`, { key: liteT1Key, iv: liteT1Iv });
+
+      const dataMap = {
+        dev: params.cookie?.KUGOU_API_DEV,
+        force_login: 1,
+        partnerid: 1,
+        clienttime_ms: dateNow,
+        t1: isLite ? t1 : 0,
+        t2: isLite ? t2 : 0,
+        t3: 'MCwwLDAsMCwwLDAsMCwwLDA=',
+        third_appid: isLite ? qq_lite_appid : qq_appid,
+        openid,
+        params: encrypt.str,
+        pk,
+      };
+
+      const response = await useAxios({
+        url: `/v6/login_by_openplat`,
+        method: 'POST',
+        data: dataMap,
+        cookie: params?.cookie,
+        encryptType: 'android',
+        headers: { 'x-router': 'login.user.kugou.com' },
+      });
+
+      if (response.body?.status === 1) {
+        const getToken = cryptoAesDecrypt(response.body.data?.secu_params, encrypt.key);
+        if (typeof getToken === 'object') {
+          response.body.data = { ...response.body.data, ...getToken };
+          Object.keys(getToken).forEach((key) => response.cookie.push(`${key}=${getToken[key]}`));
+        } else {
+          response.body.data['token'] = getToken;
+          response.cookie.push(`token=${getToken}`);
+        }
+        response.cookie.push(`t1=${response.body.data?.t1 ?? ''}`);
+        response.cookie.push(`userid=${response.body.data?.userid || 0}`);
+        response.cookie.push(`vip_type=${response.body.data?.vip_type || 0}`);
+        response.cookie.push(`vip_token=${response.body.data?.vip_token || ''}`);
+      }
+      resolve(response);
+    } catch (error) {
+      answer.status = 502;
+      answer.body = { status: 0, msg: error };
+      reject(answer);
+    }
+  });
+};

--- a/module/login_qq_qr_check.js
+++ b/module/login_qq_qr_check.js
@@ -1,0 +1,222 @@
+// QQ 扫码登录 - 检测扫码状态
+const axios = require('axios');
+const { cryptoAesDecrypt, cryptoAesEncrypt, cryptoRSAEncrypt, qq_appid, qq_lite_appid, isLite, resolveProxy } = require('../util');
+
+const proxy = resolveProxy() || false;
+
+let liteT2Key = 'fd14b35e3f81af3817a20ae7adae7020';
+let liteT2Iv = '17a20ae7adae7020';
+let liteT1Key = '5e4ef500e9597fe004bd09a46d8add98';
+let liteT1Iv = '04bd09a46d8add98';
+
+const cookieToString = (cookie) => {
+  if (typeof cookie === 'string') return cookie;
+  if (cookie && typeof cookie === 'object') {
+    return Object.entries(cookie)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('; ');
+  }
+  return '';
+};
+
+module.exports = (params, useAxios) => {
+  const answer = { status: 500, body: {}, cookie: [] };
+  return new Promise(async (resolve, reject) => {
+    try {
+      const qrsig = params?.qrsig || '';
+      const ptqrtoken = params?.ptqrtoken || '';
+      const pt_login_sig = params?.pt_login_sig || '';
+      const pt_openlogin_data = params?.pt_openlogin_data || '';
+      const xlogin_url = params?.xlogin_url || '';
+
+      let cookie = cookieToString(params?.cookie);
+      if (pt_login_sig && !cookie.includes('pt_login_sig')) {
+        cookie = `${cookie ? cookie + '; ' : ''}pt_login_sig=${pt_login_sig}`;
+      }
+
+      const missing = [];
+      if (!qrsig) missing.push('qrsig');
+      if (!ptqrtoken) missing.push('ptqrtoken');
+      if (!pt_login_sig) missing.push('pt_login_sig');
+      if (!pt_openlogin_data) missing.push('pt_openlogin_data');
+      if (!xlogin_url) missing.push('xlogin_url');
+      if (!cookie || !cookie.includes('qrsig=')) missing.push('cookie');
+
+      if (missing.length > 0) {
+        answer.status = 502;
+        answer.body = { status: 0, msg: `缺少 ${missing.join('、')}（请先调用 /login/qq/qr/create，并将返回字段原样传入 check 接口）` };
+        reject(answer);
+        return;
+      }
+
+      const clientId = isLite ? qq_lite_appid : qq_appid;
+      const sUrl = 'http://connect.qq.com';
+      const u1 = encodeURIComponent(sUrl);
+      const pollUrl = `https://xui.ptlogin2.qq.com/ssl/ptqrlogin?u1=${u1}&from_ui=1&type=1&ptlang=2052&ptqrtoken=${ptqrtoken}&daid=381&aid=716027609&pt_3rd_aid=${clientId}&pt_openlogin_data=${pt_openlogin_data}&device=2&ptopt=1&pt_uistyle=35&jsver=v1.36.0&login_sig=${encodeURIComponent(
+        pt_login_sig
+      )}&r=${Math.random()}`;
+
+      const pollResp = await axios({
+        url: pollUrl,
+        method: 'GET',
+        proxy,
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+          Referer: xlogin_url || 'https://xui.ptlogin2.qq.com/',
+          Cookie: cookie,
+        },
+      });
+
+      const pollSetCookies = pollResp.headers?.['set-cookie'] || [];
+      pollSetCookies.forEach((c) => {
+        const kv = c.split(';')[0];
+        const idx = kv.indexOf('=');
+        if (idx > 0 && !cookie.includes(kv.slice(0, idx))) {
+          cookie = `${cookie ? cookie + '; ' : ''}${kv}`;
+        }
+      });
+
+      const body = String(pollResp.data);
+      const match = body.match(/ptuiCB\((.+)\)/);
+      if (!match) {
+        answer.status = 502;
+        answer.body = { status: 0, msg: 'ptqrlogin 响应解析失败', data: body.slice(0, 200) };
+        reject(answer);
+        return;
+      }
+
+      const parts = match[1].match(/'([^']*)'/g).map((p) => p.slice(1, -1));
+      const code = parts[0];
+      const url = parts[2];
+      const msg = parts[4];
+
+      if (code === '66') {
+        answer.status = 200;
+        answer.body = { status: 'wait', qrsig, ptqrtoken, msg: '等待扫码' };
+        resolve(answer);
+        return;
+      }
+
+      if (code === '65') {
+        answer.status = 200;
+        answer.body = { status: 'expired', qrsig, ptqrtoken, msg: '二维码已失效，请重新生成' };
+        resolve(answer);
+        return;
+      }
+
+      if (code === '0') {
+        let openid = url.match(/openid=([^&#]+)/)?.[1] || '';
+        let access_token = url.match(/access_token=([^&#]+)/)?.[1] || '';
+
+        if (!openid || !access_token) {
+          let sigCookie = cookie;
+          let sigUrl = url.startsWith('http') ? url : `https://${url}`;
+          for (let hop = 0; hop < 10; hop++) {
+            try {
+              const sigResp = await axios({
+                url: sigUrl,
+                method: 'GET',
+                proxy,
+                maxRedirects: 0,
+                validateStatus: (s) => s >= 200 && s < 400,
+                headers: {
+                  'User-Agent': 'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+                  Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+                  'Accept-Language': 'zh-CN,zh;q=0.9',
+                  Referer: xlogin_url || 'https://xui.ptlogin2.qq.com/',
+                  'Sec-Fetch-Dest': 'document',
+                  'Sec-Fetch-Mode': 'navigate',
+                  'Sec-Fetch-Site': 'cross-site',
+                  Cookie: sigCookie,
+                },
+              });
+              const loc = sigResp.headers?.location;
+              const currentUrl = sigUrl;
+              openid = currentUrl.match(/openid=([^&#]+)/)?.[1] || '';
+              access_token = currentUrl.match(/access_token=([^&#]+)/)?.[1] || '';
+              if (openid && access_token) break;
+              if (!loc) {
+                const text = String(sigResp.data || '');
+                openid = text.match(/openid["']?[:=]["']?([^&"'\s]+)/)?.[1] || openid;
+                access_token = text.match(/access_token["']?[:=]["']?([^&"'\s]+)/)?.[1] || access_token;
+                break;
+              }
+              sigUrl = loc.startsWith('http') ? loc : new URL(loc, sigUrl).toString();
+              if (/^[a-z]+:\/\//.test(loc) && !/^https?:/.test(loc)) {
+                openid = sigUrl.match(/openid=([^&#]+)/)?.[1] || '';
+                access_token = sigUrl.match(/access_token=([^&#]+)/)?.[1] || '';
+                break;
+              }
+            } catch (e) {
+              break;
+            }
+          }
+        }
+
+        if (!openid || !access_token) {
+          answer.status = 502;
+          answer.body = { status: 0, msg: '登录成功但未获取到 openid/access_token', url };
+          reject(answer);
+          return;
+        }
+
+        const dateNow = Date.now();
+        const encrypt = cryptoAesEncrypt({ access_token });
+        const pk = cryptoRSAEncrypt({ clienttime_ms: dateNow, key: encrypt.key }).toUpperCase();
+        const t2 = cryptoAesEncrypt(
+          `${params.cookie?.KUGOU_API_GUID}|0f607264fc6318a92b9e13c65db7cd3c|${params.cookie?.KUGOU_API_MAC}|${params.cookie?.KUGOU_API_DEV}|${dateNow}`,
+          { key: liteT2Key, iv: liteT2Iv }
+        );
+        const t1 = cryptoAesEncrypt(`|${dateNow}`, { key: liteT1Key, iv: liteT1Iv });
+
+        const dataMap = {
+          dev: params.cookie?.KUGOU_API_DEV,
+          force_login: 1,
+          partnerid: 1,
+          clienttime_ms: dateNow,
+          t1: isLite ? t1 : 0,
+          t2: isLite ? t2 : 0,
+          t3: 'MCwwLDAsMCwwLDAsMCwwLDA=',
+          third_appid: clientId,
+          openid,
+          params: encrypt.str,
+          pk,
+        };
+
+        const loginResp = await useAxios({
+          url: `/v6/login_by_openplat`,
+          method: 'POST',
+          data: dataMap,
+          cookie: params.cookie,
+          encryptType: 'android',
+          headers: { 'x-router': 'login.user.kugou.com' },
+        });
+
+        if (loginResp.body?.status === 1) {
+          const getToken = cryptoAesDecrypt(loginResp.body.data?.secu_params, encrypt.key);
+          if (typeof getToken === 'object') {
+            loginResp.body.data = { ...loginResp.body.data, ...getToken };
+            Object.keys(getToken).forEach((key) => loginResp.cookie.push(`${key}=${getToken[key]}`));
+          } else {
+            loginResp.body.data['token'] = getToken;
+            loginResp.cookie.push(`token=${getToken}`);
+          }
+          loginResp.cookie.push(`t1=${loginResp.body.data?.t1 ?? ''}`);
+          loginResp.cookie.push(`userid=${loginResp.body.data?.userid || 0}`);
+          loginResp.cookie.push(`vip_type=${loginResp.body.data?.vip_type || 0}`);
+          loginResp.cookie.push(`vip_token=${loginResp.body.data?.vip_token || ''}`);
+        }
+        resolve(loginResp);
+        return;
+      }
+
+      answer.status = 200;
+      answer.body = { status: code, qrsig, ptqrtoken, msg };
+      resolve(answer);
+    } catch (e) {
+      answer.status = 502;
+      answer.body = { status: 0, msg: e };
+      reject(answer);
+    }
+  });
+};

--- a/module/login_qq_qr_create.js
+++ b/module/login_qq_qr_create.js
@@ -1,0 +1,135 @@
+// QQ 扫码登录 - 生成二维码
+const axios = require('axios');
+const { cryptoMd5, qq_appid, qq_lite_appid, isLite, resolveProxy } = require('../util');
+
+const APK_SIG_MD5 = 'fe4a24d80fcf253a00676a808f62c2c6';
+const proxy = resolveProxy() || false;
+
+const hash33 = (str) => {
+  let e = 0;
+  for (let i = 0; i < str.length; i++) {
+    e += (e << 5) + str.charCodeAt(i);
+  }
+  return 2147483647 & e;
+};
+
+module.exports = (params, useAxios) => {
+  const answer = { status: 500, body: {}, cookie: [] };
+  return new Promise(async (resolve, reject) => {
+    try {
+      const clientId = isLite ? qq_lite_appid : qq_appid;
+      const time = Math.floor(Date.now() / 1000);
+      const sign = cryptoMd5(`${APK_SIG_MD5}_${time}`);
+
+      const authParams = new URLSearchParams({
+        cancel_display: '1',
+        sdkp: 'a',
+        display: 'mobile',
+        format: 'json',
+        sign,
+        sdkv: '3.5.11.lite',
+        response_type: 'token',
+        status_os: '11',
+        client_id: clientId,
+        switch: '1',
+        status_version: '30',
+        show_download_ui: 'true',
+        pf: 'openmobile_android',
+        scope: 'all',
+        compat_v: '1',
+        status_machine: 'MEIZU+18+Pro',
+        style: 'qr',
+        time,
+        redirect_uri: 'auth://tauth.qq.com/',
+      });
+      const authResp = await axios({
+        url: `https://openmobile.qq.com/oauth2.0/m_authorize?${authParams.toString()}`,
+        method: 'GET',
+        proxy,
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+          Referer: 'https://xui.ptlogin2.qq.com/',
+        },
+      });
+
+      const srcMatch = authResp.data?.match(/src = "([^"]+)"/);
+      if (!srcMatch) {
+        answer.status = 502;
+        answer.body = { status: 0, msg: 'm_authorize 响应异常，未找到 xlogin 地址', data: String(authResp.data).slice(0, 300) };
+        reject(answer);
+        return;
+      }
+      const xloginUrl = srcMatch[1].replace(/\\x([0-9A-Fa-f]{2})/g, (m, h) => String.fromCharCode(parseInt(h, 16)));
+
+      const xloginQuery = xloginUrl.split('?')[1] || '';
+      const pt_openlogin_data = encodeURIComponent(xloginQuery);
+
+      const cookieJar = {};
+      const cookieStr = () =>
+        Object.entries(cookieJar)
+          .map(([k, v]) => `${k}=${v}`)
+          .join('; ');
+      const xloginResp = await axios({
+        url: xloginUrl,
+        method: 'GET',
+        proxy,
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+          Referer: 'https://xui.ptlogin2.qq.com/',
+        },
+      });
+      const setCookies = xloginResp.headers['set-cookie'] || [];
+      setCookies.forEach((c) => {
+        const kv = c.split(';')[0];
+        const idx = kv.indexOf('=');
+        if (idx > 0) cookieJar[kv.slice(0, idx)] = kv.slice(idx + 1);
+      });
+      const pt_login_sig = cookieJar['pt_login_sig'];
+
+      const t = Math.random();
+      const qrResp = await axios({
+        url: `https://xui.ptlogin2.qq.com/ssl/ptqrshow?s=8&e=0&appid=716027609&type=0&t=${t}&daid=381&pt_3rd_aid=${clientId}`,
+        method: 'GET',
+        proxy,
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+          Referer: xloginUrl,
+          Cookie: cookieStr(),
+        },
+        responseType: 'arraybuffer',
+      });
+      const qrSetCookies = qrResp.headers['set-cookie'] || [];
+      qrSetCookies.forEach((c) => {
+        const kv = c.split(';')[0];
+        const idx = kv.indexOf('=');
+        if (idx > 0) cookieJar[kv.slice(0, idx)] = kv.slice(idx + 1);
+      });
+      const qrsig = cookieJar['qrsig'];
+
+      if (!qrsig) {
+        answer.status = 502;
+        answer.body = { status: 0, msg: '未获取到 qrsig' };
+        reject(answer);
+        return;
+      }
+
+      const ptqrtoken = hash33(qrsig);
+
+      answer.status = 200;
+      answer.body = {
+        qrcode: Buffer.from(qrResp.data).toString('base64'),
+        qrsig,
+        ptqrtoken,
+        pt_login_sig: pt_login_sig || '',
+        pt_openlogin_data,
+        xlogin_url: xloginUrl,
+        cookie: cookieStr(),
+      };
+      resolve(answer);
+    } catch (e) {
+      answer.status = 502;
+      answer.body = { status: 0, msg: e };
+      reject(answer);
+    }
+  });
+};

--- a/util/config.json
+++ b/util/config.json
@@ -8,5 +8,7 @@
   "apiver": 20,
   "clientver": 20489,
   "liteAppid": 3116,
-  "liteClientver": 11440
+  "liteClientver": 11440,
+  "qq_appid": "205141",
+  "qq_lite_appid": "101706348"
 }

--- a/util/index.js
+++ b/util/index.js
@@ -13,7 +13,7 @@
  */
 
 // ========== 配置常量 ==========
-const { apiver, appid, wx_appid, wx_lite_appid, wx_secret, wx_lite_secret, srcappid, clientver, liteAppid, liteClientver } = require('./config.json');
+const { apiver, appid, wx_appid, wx_lite_appid, wx_secret, wx_lite_secret, srcappid, clientver, liteAppid, liteClientver, qq_appid, qq_lite_appid } = require('./config.json');
 
 // ========== 加密函数 ==========
 const {
@@ -31,6 +31,7 @@ const {
 
 // ========== 请求函数 ==========
 const { createRequest } = require('./request');
+const { resolveProxy } = require('./runtime');
 
 // ========== 签名函数 ==========
 const { signKey, signParams, signParamsKey, signCloudKey, signatureAndroidParams, signatureRegisterParams, signatureWebParams } = require('./helper');
@@ -60,6 +61,8 @@ module.exports = {
   wx_lite_appid,                // 微信概念版小程序应用 ID
   wx_secret,                    // 微信小程序密钥
   wx_lite_secret,               // 微信概念版小程序密钥
+  qq_appid,                     // QQ 开放平台应用 ID（标准版）
+  qq_lite_appid,                // QQ 开放平台应用 ID（概念版）
   srcappid,                     // 来源应用 ID
   clientver: useClientver,      // 客户端版本号（根据平台自动选择）
   isLite,                       // 是否为概念版
@@ -76,6 +79,7 @@ module.exports = {
 
   // --- 请求函数 ---
   createRequest,                // 创建 HTTP 请求
+  resolveProxy,                 // 解析项目代理配置（KUGOU_API_PROXY）
 
   // --- 签名函数 ---
   signKey,                      // 请求密钥签名


### PR DESCRIPTION
## 变更内容

- 新增 QQ 授权登录接口 `/login/qq`
- 新增 QQ 扫码登录接口：
  - `/login/qq/qr/create`
  - `/login/qq/qr/check`
- 增加 QQ 标准版/概念版 appid 配置，并按 `platform=lite` 自动切换
- 补充 TypeScript 类型定义和接口文档
- 明确区分微信扫码/开放登录与 QQ 扫码/授权登录流程，避免参数混用

## 验证方式

- `node --check module/login_qq.js`
- `node --check module/login_qq_qr_create.js`
- `node --check module/login_qq_qr_check.js`
- `npx tsc --noEmit`

## 手动测试

已分别验证默认平台和 `platform=lite`：

1. 调用 `/login/qq/qr/create` 生成二维码
2. 使用 QQ 扫码确认登录
3. 调用 `/login/qq/qr/check?...` 获取酷狗登录态
4. 使用返回的 `userid/token` 调用 `/user/detail`

结果：QQ 登录成功，`/user/detail` 返回 `status: 1`、`error_code: 0`。