### PR TITLE
fix: forward device name during login

### DIFF
--- a/module/login.js
+++ b/module/login.js
@@ -10,6 +10,7 @@ module.exports = (params, useAxios) => {
     t1: '562a6f12a6e803453647d16a08f5f0c2ff7eee692cba2ab74cc4c8ab47fc467561a7c6b586ce7dc46a63613b246737c03a1dc8f8d162d8ce1d2c71893d19f1d4b797685a4c6d3d81341cbde65e488c4829a9b4d42ef2df470eb102979fa5adcdd9b4eecfea8b909ff7599abeb49867640f10c3c70fc444effca9d15db44a9a6c907731e2bb0f22cd9b3536380169995693e5f0e2424e3378097d3813186e3fe96bbe7023808a0981b4e2b6135a76faac',
     t2: '31c4daf4cf480169ccea1cb7d4a209295865a9d2b788510301694db229b87807469ea0d41b4d4b9173c2151da7294aeebfc9738df154bbdf11a4e117bb5dff6a3af8ce5ce333e681c1f29a44038f27567d58992eb81283e080778ac77db1400fdf49b7cf7e26be2e5af4da7830cc3be4',
     t3: 'MCwwLDAsMCwwLDAsMCwwLDA=',
+    dev: params?.cookie?.KUGOU_API_DEV,
     username: params?.username,
     params: encrypt.str,
     pk: cryptoRSAEncrypt({ 'clienttime_ms': dateNow, key: encrypt.key }).toUpperCase(),

--- a/module/login_qr_check.js
+++ b/module/login_qr_check.js
@@ -8,15 +8,23 @@ module.exports = (params, useAxios) => {
       baseURL: 'https://login-user.kugou.com',
       url: '/v2/get_userinfo_qrcode',
       method: 'GET',
-      params: { plat: 4, appid, srcappid, qrcode: params?.key },
+      params: {
+        plat: 4,
+        appid,
+        srcappid,
+        qrcode: params?.key,
+        dev: params?.cookie?.KUGOU_API_DEV,
+      },
       encryptType: 'web',
       cookie: params?.cookie || {},
-    }).then(resp => {
-      if (resp.body?.data?.status == 4) {
-        resp.cookie.push(`token=${resp.body?.data?.token}`);
-        resp.cookie.push(`userid=${resp.body?.data?.userid}`);
-      }
-      resolve(resp);
-    }).catch(e => reject(e));
+    })
+      .then((resp) => {
+        if (resp.body?.data?.status == 4) {
+          resp.cookie.push(`token=${resp.body?.data?.token}`);
+          resp.cookie.push(`userid=${resp.body?.data?.userid}`);
+        }
+        resolve(resp);
+      })
+      .catch((e) => reject(e));
   });
 };


### PR DESCRIPTION
## 问题

服务端虽然会将 `KUGOU_API_DEV` 注入 Cookie，但以下登录链路没有将其传递给酷狗登录接口：

- 酷狗二维码登录 `/login/qr/check`
- 账号密码登录 `/login`

因此，即使配置了 `KUGOU_API_DEV`，登录设备列表中仍可能无法显示预期的设备名称。

## 修改

- 在 `/v2/get_userinfo_qrcode` 请求参数中增加 `dev`
- 在 `/v9/login_by_pwd` 请求体中增加 `dev`
- 两处均统一读取 `params.cookie.KUGOU_API_DEV`

这与微信、QQ、验证码及 Token 登录链路的设备名称传递方式保持一致。