### PR TITLE
feat: import playlist & artist audios v2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -167,6 +167,7 @@
 138. [`获取听歌等级信息`](#获取听歌等级信息)
 139. [`编辑内容黑名单`](#编辑内容黑名单)
 140. [`获取内容黑名单`](#获取内容黑名单)
+141. [`导入外部歌单`](#导入外部歌单)
 
 ### 安装
 
@@ -898,6 +899,22 @@ fileids: 歌单中歌曲的 fileid，可多个,用逗号隔开
 **接口地址：** `/playlist/tracks/del`
 
 **调用例子：** `/playlist/tracks/del?listid=1&fileids=xx` `/playlist/tracks/del?listid=1&fileids=xx,xx`
+
+### 导入外部歌单
+
+说明：登录后调用此接口，可通过外部歌单链接或歌单截图创建酷狗云端导入任务。接口统一使用 `POST /import/playlist`，通过请求体中的 `operation` 区分操作。
+
+HTTP 服务模式存在响应缓存，调用时建议附加变化的 `timestamp` 查询参数，例如 `/import/playlist?timestamp=1691256061923`。
+
+**链接导入**：`operation=add_task`、`task_type=0`、`url=外部歌单链接`。
+
+**截图导入**：先逐张调用 `operation=submit_img`，传入相同的 `task_sn` 与 `img_base64`；上传完成后调用 `operation=add_task`，传入 `task_type=1`、`task_sn`、目标歌单 `listid` 和 `list_name`。`task_sn` 可使用 `userid + 毫秒时间戳`。
+
+**查询任务状态**：`operation=query_task_status`、`ids=[任务 ID]`。状态 `3` 表示成功，状态大于等于 `10` 表示失败，其余状态表示处理中。
+
+**查询导入结果**：`operation=query_task`、`listid=导入后的歌单 ID`，可选 `page`、`pagesize`、`show_missed`。注意这里的 `listid` 是歌单 ID，不是任务 ID。
+
+**查询任务数量**：`operation=task_count`，可选 `classify`（默认 `1`）。
 
 ### 新碟上架
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -168,6 +168,7 @@
 139. [`编辑内容黑名单`](#编辑内容黑名单)
 140. [`获取内容黑名单`](#获取内容黑名单)
 141. [`导入外部歌单`](#导入外部歌单)
+142. [`获取歌手单曲（新版）`](#获取歌手单曲新版)
 
 ### 安装
 
@@ -2861,3 +2862,23 @@ const res = await fetch('/audio/match', {
 ## License
 
 [The MIT License (MIT)](https://github.com/MakcRe/KuGouMusicApi/blob/main/LICENSE)
+
+### 获取歌手单曲（新版）
+
+说明 : 调用此接口 , 传入歌手 id, 可获得歌手歌曲（新版接口），每条歌曲带作者列表（`authors`），支持多歌手。
+
+**必选参数：**
+
+`id`： 歌手 id
+
+**可选参数：**
+
+`page`： 页码
+
+`pagesize`: 每页页数, 默认为 30（**上限 100**，超过返回 `error_code=20010`）
+
+`sort`: 排序，hot : 热门, new: 最新
+
+**接口地址：** `/artist/audios/new`
+
+**调用例子：** `/artist/audios/new?id=6539`

--- a/module/artist_audios_new.js
+++ b/module/artist_audios_new.js
@@ -1,0 +1,24 @@
+// 获取歌手单曲（新版接口，返回每条歌曲的作者列表，支持多歌手）
+// 注意：本接口 pagesize 上限为 100，超过会返回 error_code=20010
+module.exports = (params, useAxios) => {
+  return useAxios({
+    baseURL: 'https://gateway.kugou.com',
+    url: '/openapi/kmr/v2/audio_group/author',
+    method: 'GET',
+    params: {
+      author_id: params.id,
+      area_code: 'all',
+      sort: params?.sort === 'hot' ? 1 : 2, // 1：最热，2：最新
+      page: params?.page || 1,
+      pagesize: params?.pagesize || 30,
+      replace_api_version: 1,
+      mvdata_need: 1,
+      show_audio_honor: 1,
+      show_audio_tag: 1,
+      replace_need: 1,
+    },
+    encryptType: 'android',
+    cookie: params?.cookie || {},
+    headers: { 'kg-tid': 36 },
+  });
+};

--- a/module/import_playlist.js
+++ b/module/import_playlist.js
@@ -1,0 +1,108 @@
+const { appid, clientver, liteAppid, liteClientver } = require('../util/config.json');
+
+const GATEWAY_BASE = 'https://gateway.kugou.com';
+
+const parseBody = (body) => {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return {};
+  return body;
+};
+
+const parseIds = (value) => {
+  if (Array.isArray(value)) return value.map(Number).filter(Number.isFinite);
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) return parsed.map(Number).filter(Number.isFinite);
+    } catch {}
+    return value.split(',').map(Number).filter(Number.isFinite);
+  }
+  const id = Number(value);
+  return Number.isFinite(id) ? [id] : [];
+};
+
+module.exports = (params, useAxios) => {
+  const input = { ...params, ...parseBody(params?.body) };
+  const cookie = params?.cookie || {};
+  const userid = String(input.userid || cookie.userid || '');
+  const token = input.token || cookie.token || '';
+  const operation = input.operation;
+  const isLite = process.env.platform === 'lite';
+  const clienttime = Math.floor(Date.now() / 1000);
+
+  const query = {
+    appid: String(isLite ? liteAppid : appid),
+    clientver: String(isLite ? liteClientver : clientver),
+    clienttime: String(clienttime),
+    mid: String(input.mid || cookie.KUGOU_API_MID || '-'),
+    uuid: String(input.uuid || cookie.uuid || '-'),
+    dfid: String(input.dfid || cookie.dfid || '-'),
+  };
+
+  const common = {
+    baseURL: GATEWAY_BASE,
+    method: 'POST',
+    params: query,
+    cookie,
+    headers: { 'Content-Type': 'application/json;charset=utf-8' },
+    encryptType: 'android',
+    clearDefaultParams: true,
+  };
+
+  if (operation === 'add_task') {
+    const taskType = Number(input.task_type || 0);
+    const data = { userid, token, source: Number(input.source || 3), task_type: taskType };
+    if (taskType === 0) {
+      data.url = String(input.url || '');
+    } else {
+      data.listid = Number(input.listid || 0);
+      if (input.list_name) data.list_name = String(input.list_name);
+      data.task_sn = String(input.task_sn || `${userid}${Date.now()}`);
+    }
+    return useAxios({ ...common, url: '/assetservice/import/v1/add_task', data });
+  }
+
+  if (operation === 'submit_img') {
+    const imgBase64 = String(input.img_base64 || '').replace(/^data:image\/[^;]+;base64,/, '');
+    return useAxios({
+      ...common,
+      url: '/assetservice/import/v1/submit_img',
+      data: { userid, token, img_base64: imgBase64, task_sn: String(input.task_sn || '') },
+    });
+  }
+
+  if (operation === 'task_count') {
+    return useAxios({
+      ...common,
+      url: '/assetservice/import/v1/task_count',
+      data: { userid, token, classify: Number(input.classify || 1) },
+    });
+  }
+
+  if (operation === 'query_task_status') {
+    return useAxios({
+      ...common,
+      url: '/assetservice/import/v1/query_task_status',
+      data: { userid, token, ids: parseIds(input.ids) },
+    });
+  }
+
+  if (operation === 'query_task') {
+    return useAxios({
+      ...common,
+      url: '/pubsongs/v1/query_task',
+      data: {
+        userid,
+        token,
+        listid: String(input.listid || ''),
+        page: Math.max(1, Number(input.page || 1)),
+        pagesize: Math.max(1, Number(input.pagesize || 30)),
+        show_missed: Number(input.show_missed ?? 1) ? 1 : 0,
+      },
+    });
+  }
+
+  return Promise.reject({
+    status: 400,
+    body: { status: 0, error_code: 400, error_msg: `不支持的操作: ${operation || ''}` },
+  });
+};

--- a/server.js
+++ b/server.js
@@ -282,7 +282,7 @@ async function consturctServer(moduleDefs) {
    * - express.urlencoded(): 解析 Content-Type 为 application/x-www-form-urlencoded 的请求体
    *   - extended: false 使用 querystring 库解析（不支持嵌套对象）
    */
-  app.use(express.json({ limit: '5mb' }));
+  app.use(express.json({ limit: '16mb' }));
   app.use(express.urlencoded({ extended: false, limit: '5mb' }));
   app.use(express.raw({ type: 'application/octet-stream', limit: '100mb' }));
 


### PR DESCRIPTION
### 改动

- 新增 module/import_playlist.js，统一路由 POST /import/playlist，通过请求体 operation 区分操作：
- add_task：提交导入任务（task_type=0 链接导入 / task_type=1 截图导入）
- submit_img：上传歌单截图（base64，最多 9 张）
- query_task_status：查询任务状态（3 成功，>=10 失败）
- query_task：查询导入结果（listid 为歌单 ID）
- task_count：查询导入任务数量

- server.js：JSON 请求体上限 5mb → 16mb（截图 base64 需要）
- docs/README.md：新增「导入外部歌单」接口文档

### 获取歌手单曲（新版）：返回每条歌曲的作者列表，支持多歌手

**背景**

原有 `/artist/audios`（`/kmr/v1/audio_group/author`）返回的歌曲不含歌手 ID，只有 `author_name`，无法处理多歌手歌曲。酷狗官方 App 已升级使用新版接口，每条歌曲带 `authors` 数组，可返回全部合作歌手及其 ID。

**改动**

- 新增 `module/artist_audios_new.js`，路由 `GET /artist/audios/new`，调用酷狗新版接口 `/openapi/kmr/v2/audio_group/author`
- 响应 `data.songs[]` 每条歌曲含：
  - `authors`: `[{ base: { author_id, author_name, avatar, ... } }]` 完整作者列表（多歌手返回多项）
  - `audio_info`（hash、音质）、`album_info`、`privilege_download` 等
- `docs/README.md`：新增「获取歌手单曲（新版）」接口文档

**参数**

| 参数 | 说明 |
|------|------|
| `id` | 歌手 id（必选） |
| `page` / `pagesize` | 分页，默认 30 |
| `sort` | `hot` 热门 / `new` 最新 |

**注意**

- `pagesize` 上限为 **100**，超过返回 `error_code=20010`
- 调用例子：`/artist/audios/new?id=6539`