### PR TITLE
feat: 新增歌手单曲新版接口，返回歌曲作者列表

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -167,6 +167,7 @@
 138. [`获取听歌等级信息`](#获取听歌等级信息)
 139. [`编辑内容黑名单`](#编辑内容黑名单)
 140. [`获取内容黑名单`](#获取内容黑名单)
+141. [`获取歌手单曲（新版）`](#获取歌手单曲新版)
 
 ### 安装
 
@@ -2844,3 +2845,23 @@ const res = await fetch('/audio/match', {
 ## License
 
 [The MIT License (MIT)](https://github.com/MakcRe/KuGouMusicApi/blob/main/LICENSE)
+
+### 获取歌手单曲（新版）
+
+说明 : 调用此接口 , 传入歌手 id, 可获得歌手歌曲（新版接口），每条歌曲带作者列表（`authors`），支持多歌手。
+
+**必选参数：**
+
+`id`： 歌手 id
+
+**可选参数：**
+
+`page`： 页码
+
+`pagesize`: 每页页数, 默认为 30（**上限 100**，超过返回 `error_code=20010`）
+
+`sort`: 排序，hot : 热门, new: 最新
+
+**接口地址：** `/artist/audios/new`
+
+**调用例子：** `/artist/audios/new?id=6539`

--- a/module/artist_audios_new.js
+++ b/module/artist_audios_new.js
@@ -1,0 +1,24 @@
+// 获取歌手单曲（新版接口，返回每条歌曲的作者列表，支持多歌手）
+// 注意：本接口 pagesize 上限为 100，超过会返回 error_code=20010
+module.exports = (params, useAxios) => {
+  return useAxios({
+    baseURL: 'https://gateway.kugou.com',
+    url: '/openapi/kmr/v2/audio_group/author',
+    method: 'GET',
+    params: {
+      author_id: params.id,
+      area_code: 'all',
+      sort: params?.sort === 'hot' ? 1 : 2, // 1：最热，2：最新
+      page: params?.page || 1,
+      pagesize: params?.pagesize || 30,
+      replace_api_version: 1,
+      mvdata_need: 1,
+      show_audio_honor: 1,
+      show_audio_tag: 1,
+      replace_need: 1,
+    },
+    encryptType: 'android',
+    cookie: params?.cookie || {},
+    headers: { 'kg-tid': 36 },
+  });
+};


### PR DESCRIPTION
### 获取歌手单曲（新版）：返回每条歌曲的作者列表，支持多歌手

**背景**

原有 `/artist/audios`（`/kmr/v1/audio_group/author`）返回的歌曲不含歌手 ID，只有 `author_name`，无法处理多歌手歌曲。酷狗官方 App 已升级使用新版接口，每条歌曲带 `authors` 数组，可返回全部合作歌手及其 ID。

**改动**

- 新增 `module/artist_audios_new.js`，路由 `GET /artist/audios/new`，调用酷狗新版接口 `/openapi/kmr/v2/audio_group/author`
- 响应 `data.songs[]` 每条歌曲含：
  - `authors`: `[{ base: { author_id, author_name, avatar, ... } }]` 完整作者列表（多歌手返回多项）
  - `audio_info`（hash、音质）、`album_info`、`privilege_download` 等
- `docs/README.md`：新增「获取歌手单曲（新版）」接口文档

**参数**

| 参数 | 说明 |
|------|------|
| `id` | 歌手 id（必选） |
| `page` / `pagesize` | 分页，默认 30 |
| `sort` | `hot` 热门 / `new` 最新 |

**注意**

- `pagesize` 上限为 **100**，超过返回 `error_code=20010`
- 调用例子：`/artist/audios/new?id=6539`