### PR TITLE
feat(login): 新增二维码授权登录接口 /login/qr/authorize，web 签名支持将请求体纳入计算

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -495,23 +495,23 @@ $ set HOST=127.0.0.1 && npm run dev
 
 ##### 3. 二维码授权登录接口
 
-说明: 使用当前已登录账号为二维码对应的新设备授权登录，对应扫码登录新设备场景。cookie 中必须包含当前账号的 `token`、`userid`。
+说明: 登陆后调用此接口，授权其他设备登录
 
 **必选参数：**
 
 `qrcode`: 二维码 key，从新设备登录二维码中提取
 
-`appid`: 纯数字，从新设备登录二维码中提取
-
 `cookie`: 含已登录账号的 `token`、`userid`
 
 **可选参数：**
+
+`appid`: 未传时使用服务器当前平台配置的 appid，必须与当前 token 对应平台一致
 
 `plat`: 请求体 plat 字段，默认 `1`，传入 `2` 时使用 `2`
 
 **接口地址：** `/login/qr/authorize`
 
-**调用例子：** `/login/qr/authorize?qrcode=xxx&appid=1005&cookie=token%3Dxxx%3B%20userid%3Dxxx`
+**调用例子：** `/login/qr/authorize?qrcode=xxx&cookie=token%3Dxxx%3B%20userid%3Dxxx`
 
 #### 6. 微信扫码登录
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -493,6 +493,26 @@ $ set HOST=127.0.0.1 && npm run dev
 
 **调用例子：** `/login/qr/check?key=xxx`
 
+##### 3. 二维码授权登录接口
+
+说明: 使用当前已登录账号为二维码对应的新设备授权登录，对应扫码登录新设备场景。cookie 中必须包含当前账号的 `token`、`userid`。
+
+**必选参数：**
+
+`qrcode`: 二维码 key，从新设备登录二维码中提取
+
+`appid`: 纯数字，从新设备登录二维码中提取
+
+`cookie`: 含已登录账号的 `token`、`userid`
+
+**可选参数：**
+
+`plat`: 请求体 plat 字段，默认 `1`，传入 `2` 时使用 `2`
+
+**接口地址：** `/login/qr/authorize`
+
+**调用例子：** `/login/qr/authorize?qrcode=xxx&appid=1005&cookie=token%3Dxxx%3B%20userid%3Dxxx`
+
 #### 6. 微信扫码登录
 
 说明：微信扫码登录涉及到 2 个接口,调用务必带上时间戳,防止缓存。该流程使用微信的 `uuid` / `wx_code`，不适用于 QQ 扫码登录。

--- a/module/login_qr_authorize.js
+++ b/module/login_qr_authorize.js
@@ -1,8 +1,10 @@
-const { srcappid, clientver } = require('../util')
+const { appid, srcappid, clientver } = require('../util')
 
 // 使用当前已登录账号授权二维码对应的新设备登录。
 // qrcode 是二维码 key，从新设备登录二维码中提取，cookie 中必须包含当前账号的 token、userid
-// appid 是对应新设备的 appid，从新设备登录二维码中提取
+// appid 为可选参数，不做校验，未传时直接使用当前平台配置的 appid；
+// 无论是否传入，最终请求的 appid 必须与当前 token 对应平台一致
+// 而非二维码所属端的 appid，否则上游会返回 error_code 20018
 module.exports = (params, useAxios) => {
   const qrcode = params?.qrcode
   if (!qrcode || !/^[\w-]+$/.test(qrcode)) {
@@ -22,15 +24,8 @@ module.exports = (params, useAxios) => {
     })
   }
 
-  // appid 为必传参数，必须为纯数字，从新设备登录二维码中提取
-  if (!params?.appid || !/^\d+$/.test(String(params.appid))) {
-    return Promise.reject({
-      status: 400,
-      body: { status: 0, error_code: 400, msg: '缺少有效的 appid 参数（必传，纯数字）' },
-      cookie: [],
-    })
-  }
-  const requestAppid = Number(params.appid)
+  // appid 为可选参数，不做校验，未传时直接使用当前平台配置的 appid
+  const requestAppid = params?.appid || appid
 
   // 与线上 H5 (loginQRCode) 的 kGRequest 请求保持一致：
   // 查询参数 appid/clientver/clienttime/mid/uuid/dfid 由 createRequest 注入，

--- a/module/login_qr_authorize.js
+++ b/module/login_qr_authorize.js
@@ -1,0 +1,91 @@
+const { srcappid, clientver } = require('../util')
+
+// 使用当前已登录账号授权二维码对应的新设备登录。
+// qrcode 是二维码 key，从新设备登录二维码中提取，cookie 中必须包含当前账号的 token、userid
+// appid 是对应新设备的 appid，从新设备登录二维码中提取
+module.exports = (params, useAxios) => {
+  const qrcode = params?.qrcode
+  if (!qrcode || !/^[\w-]+$/.test(qrcode)) {
+    return Promise.reject({
+      status: 400,
+      body: { status: 0, error_code: 400, msg: '缺少有效的 qrcode 参数' },
+      cookie: [],
+    })
+  }
+
+  const cookie = params?.cookie || {}
+  if (!cookie.token || !cookie.userid) {
+    return Promise.reject({
+      status: 400,
+      body: { status: 0, error_code: 400, msg: 'cookie 中缺少已登录账号的 token 或 userid' },
+      cookie: [],
+    })
+  }
+
+  // appid 为必传参数，必须为纯数字，从新设备登录二维码中提取
+  if (!params?.appid || !/^\d+$/.test(String(params.appid))) {
+    return Promise.reject({
+      status: 400,
+      body: { status: 0, error_code: 400, msg: '缺少有效的 appid 参数（必传，纯数字）' },
+      cookie: [],
+    })
+  }
+  const requestAppid = Number(params.appid)
+
+  // 与线上 H5 (loginQRCode) 的 kGRequest 请求保持一致：
+  // 查询参数 appid/clientver/clienttime/mid/uuid/dfid 由 createRequest 注入，
+  // 请求体仅包含 plat/userid/token/qrcode/type，签名会包含该请求体字符串。
+  const requestOptions = {
+    baseURL: 'https://login-user.kugou.com',
+    method: 'POST',
+    params: {
+      appid: requestAppid,
+      srcappid,
+      clientver,
+    },
+    data: JSON.stringify({
+      plat: params?.plat === 2 ? 2 : 1,
+      userid: cookie.userid,
+      token: cookie.token,
+      qrcode,
+      type: 1,
+    }),
+    headers: { 'Content-Type': 'application/json' },
+    encryptType: 'web',
+    cookie,
+  }
+
+  // H5 页面先调用 scan 登记扫码行为，确认后再调用 authorize 完成授权。
+  return useAxios({ ...requestOptions, url: '/v2/scan' }).then((scanResponse) => {
+    const scanData = scanResponse.body?.data
+    if (scanResponse.body?.status !== 1 || String(scanData?.userid) !== String(cookie.userid)) {
+      return {
+        ...scanResponse,
+        body: {
+          ...scanResponse.body,
+          data: {
+            ...scanData,
+            qrcode,
+            appid: requestAppid,
+            authorized: false,
+          },
+        },
+      }
+    }
+
+    return useAxios({ ...requestOptions, url: '/v2/authorize' }).then((authorizeResponse) => ({
+      ...authorizeResponse,
+      body: {
+        ...authorizeResponse.body,
+        data: {
+          ...authorizeResponse.body?.data,
+          qrcode,
+          appid: requestAppid,
+          authorized:
+            authorizeResponse.body?.status === 1 &&
+            String(authorizeResponse.body?.data?.userid) === String(cookie.userid),
+        },
+      },
+    }))
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.21.2
+      form-data:
+        specifier: ^4.0.0
+        version: 4.0.3
       node-forge:
         specifier: ^1.3.3
         version: 1.3.3
@@ -56,7 +59,7 @@ importers:
         version: 3.1.10
       pkg:
         specifier: ^5.8.1
-        version: 5.8.1(supports-color@5.5.0)
+        version: 5.8.1
       prettier:
         specifier: ^2.7.1
         version: 2.8.8
@@ -1658,7 +1661,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  agent-base@6.0.2(supports-color@5.5.0):
+  agent-base@6.0.2:
     dependencies:
       debug: 4.4.1(supports-color@5.5.0)
     transitivePeerDependencies:
@@ -2085,9 +2088,9 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
-  https-proxy-agent@5.0.1(supports-color@5.5.0):
+  https-proxy-agent@5.0.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@5.5.0)
+      agent-base: 6.0.2
       debug: 4.4.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
@@ -2268,11 +2271,11 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  pkg-fetch@3.4.2(supports-color@5.5.0):
+  pkg-fetch@3.4.2:
     dependencies:
       chalk: 4.1.2
       fs-extra: 9.1.0
-      https-proxy-agent: 5.0.1(supports-color@5.5.0)
+      https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
       progress: 2.0.3
       semver: 7.7.2
@@ -2282,7 +2285,7 @@ snapshots:
       - encoding
       - supports-color
 
-  pkg@5.8.1(supports-color@5.5.0):
+  pkg@5.8.1:
     dependencies:
       '@babel/generator': 7.18.2
       '@babel/parser': 7.18.4
@@ -2294,7 +2297,7 @@ snapshots:
       is-core-module: 2.9.0
       minimist: 1.2.8
       multistream: 4.1.0
-      pkg-fetch: 3.4.2(supports-color@5.5.0)
+      pkg-fetch: 3.4.2
       prebuild-install: 7.1.1
       resolve: 1.22.10
       stream-meter: 1.0.4

--- a/util/helper.js
+++ b/util/helper.js
@@ -34,15 +34,16 @@ const { appid: useAppid, liteAppid, clientver: useClientver, liteClientver } = r
  * 4. 对整体取 MD5 哈希
  *
  * @param {Object} params - 请求参数键值对
+ * @param {string} [data] - 可选的请求体字符串；H5 的 kGRequest 对 POST 请求会把 JSON 请求体拼进签名
  * @returns {string} MD5 签名字符串（32位小写hex）
  */
-const signatureWebParams = (params) => {
+const signatureWebParams = (params, data) => {
   const str = 'NVPh5oo715z5DIWAeQlhMDsWXXQV4hwt'; // Web 版签名盐值
   const paramsString = Object.keys(params)
     .map((key) => `${key}=${params[key]}`)
     .sort()    // 按 key 字母排序
     .join(''); // 拼接为连续字符串
-  return cryptoMd5(`${str}${paramsString}${str}`);
+  return cryptoMd5(`${str}${paramsString}${data || ''}${str}`);
 };
 
 /**

--- a/util/request.js
+++ b/util/request.js
@@ -129,7 +129,8 @@ const createRequest = (options) => {
           params['signature'] = signatureRegisterParams(params);
           break;
         case 'web':
-          params['signature'] = signatureWebParams(params);
+          // H5 的 kGRequest 对带请求体的 POST 会把请求体字符串拼进签名，GET 请求 data 为空串不受影响
+          params['signature'] = signatureWebParams(params, data);
           break;
         case 'android':
         default:


### PR DESCRIPTION
该接口可以已当前登录的用户身份授权新的登录请求，即产生新的登录设备、token。用于授权其他设备登录

> 仅在概念版登录情况下测试