### PR TITLE
fix(docker): 回退为 `pnpm` 依赖管理

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ RUN apk add --no-cache tini
 
 RUN corepack enable
 
-RUN npm config set registry https://registry.npmmirror.com && npm install -g pnpm --force
-
 ENV NODE_ENV=production
 
 WORKDIR /app
@@ -16,9 +14,7 @@ COPY --chown=node:node package.json pnpm-lock.yaml ./
 
 USER node
 
-#RUN pnpm install --prod --frozen-lockfile --ignore-scripts false
-
-RUN npm install --production --ignore-scripts=false
+RUN pnpm install --prod --frozen-lockfile
 
 COPY --chown=node:node . ./
 


### PR DESCRIPTION
把 Dockerfile 回退为之前 `pnpm install --prod --frozen-lockfile` 的版本。

## 动机

b74d05d 对 Dockerfile 做了一些改动，可能是为了绕过新版本 pnpm install scripts 的安全策略，但：

- `npm install` 不读 `pnpm-lock.yaml`，可复现性成谜。
- `corepack enable` 是引导 pnpm 的标准方式，再用 npm 全局安装显得神秘。
- 仓库本就使用 pnpm 管理依赖，在新版本上出问题配置好就行，直接换别的包管理有点头痛砍头的意味（

164cff2 已将 `esbuild` 从生产依赖移除，并改为开发依赖 `tsdown`，目前不用额外配置也不会再被 pnpm 拦了。

## 验证

在 `Docker 29.7.2` 中构建成功，重点关注 pnpm 安全策略的通过情况：

```
#11 13.19 ✓ Lockfile passes supply-chain policies (331 entries in 6.6s)
#11 13.63 Done in 7.1s using pnpm v12.3.4
```

完整执行过程：

```bash
$ sudo docker build --progress=plain -t kugoumusicapi:pnpm-fix .

#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 382B done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/node:lts-alpine
#2 DONE 4.2s

#3 [internal] load .dockerignore
#3 transferring context: 184B done
#3 DONE 0.0s

#4 [1/8] FROM docker.io/library/node:lts-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf
#4 DONE 0.0s

#5 [2/8] RUN apk add --no-cache tini
#5 CACHED

#6 [3/8] RUN corepack enable
#6 CACHED

#7 [internal] load build context
#7 transferring context: 840.07kB 0.0s done
#7 DONE 0.1s

#8 [4/8] WORKDIR /app
#8 DONE 0.1s

#9 [5/8] RUN chown node:node /app
#9 DONE 0.3s

#10 [6/8] COPY --chown=node:node package.json pnpm-lock.yaml ./
#10 DONE 0.0s

#11 [7/8] RUN pnpm install --prod --frozen-lockfile
#11 1.278 ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-12.3.4.tgz
#11 3.174 Downloading the pnpm 12.3.4 binary for linux-x64...
#11 6.595 ? Verifying lockfile against supply-chain policies (331 entries)...
#11 7.627 Progress: resolved 316, reused 0, downloaded 19, added 0
#11 7.799 Packages are hard linked from the content-addressable store to the virtual store.
#11 7.799   Content-addressable store is at: /home/node/.local/share/pnpm/store/v11
#11 7.799   Virtual store is at:             node_modules/.pnpm
#11 8.810 Progress: resolved 316, reused 0, downloaded 115, added 96
#11 9.151 Downloading @rolldown/binding-linux-x64-musl@1.1.1: 0.00 B/11.22 MB
#11 10.16 Progress: resolved 316, reused 0, downloaded 275, added 256
#11 10.93 [WARN] Tarball download average speed 9 KiB/s (size 13 KiB) is below 50 KiB/s: https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz (GET)
#11 12.21 Progress: resolved 316, reused 0, downloaded 313, added 288
#11 13.19 ✓ Lockfile passes supply-chain policies (331 entries in 6.6s)
#11 13.19 Lockfile is up to date, resolution step is skipped
#11 13.52 Packages: +316
#11 13.52 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
#11 13.53 Progress: resolved 316, reused 0, downloaded 316, added 316, done
#11 13.63 
#11 13.63 dependencies:
#11 13.63 + axios 1.10.0
#11 13.63 + big-integer 1.6.52
#11 13.63 + crypto-js 4.2.0
#11 13.63 + dotenv 16.6.1
#11 13.63 + express 4.21.2
#11 13.63 + form-data 4.0.3
#11 13.63 + node-forge 1.3.3
#11 13.63 + pako 2.1.0
#11 13.63 + qrcode 1.5.4
#11 13.63 + safe-decode-uri-component 1.2.1
#11 13.63 + url 0.11.4
#11 13.63 
#11 13.63 Done in 7.1s using pnpm v12.3.4
#11 DONE 13.7s

#12 [8/8] COPY --chown=node:node . ./
#12 DONE 0.2s

#13 exporting to image
#13 exporting layers
#13 exporting layers 1.7s done
#13 writing image sha256:9165ba44238450d75afa183a370f890f4045676cbfc18f6019dc5f63f5bb2ae9 done
#13 naming to docker.io/library/kugoumusicapi:pnpm-fix done
#13 DONE 1.8s
```